### PR TITLE
feat: devfile detection implemented in go

### DIFF
--- a/go/pkg/apis/recognizer/devfile_recognizer.go
+++ b/go/pkg/apis/recognizer/devfile_recognizer.go
@@ -1,0 +1,81 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc.
+ ******************************************************************************/
+package recognizer
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/redhat-developer/alizer/pkg/apis/language"
+)
+
+type DevFileType struct {
+	Name        string
+	Language    string
+	ProjectType string
+	Tags        []string
+}
+
+func SelectDevFileFromTypes(path string, devFileTypes []DevFileType) (DevFileType, error) {
+	languages, err := Analyze(path)
+	if err != nil {
+		return DevFileType{}, err
+	}
+	for _, language := range languages {
+		devfile, err := selectDevFileByLanguage(language, devFileTypes)
+		if err == nil {
+			return devfile, nil
+		}
+	}
+	return DevFileType{}, errors.New("No valid devfile found for project in " + path)
+}
+
+func selectDevFileByLanguage(language language.Language, devFileTypes []DevFileType) (DevFileType, error) {
+	scoreTarget := 0
+	devfileTarget := DevFileType{}
+	FRAMEWORK_WEIGHT := 10
+	TOOL_WEIGHT := 5
+	for _, devFile := range devFileTypes {
+		score := 0
+		if strings.EqualFold(devFile.Language, language.Name) || matches(language.Aliases, devFile.Language) {
+			score++
+			if matches(language.Frameworks, devFile.ProjectType) {
+				score += FRAMEWORK_WEIGHT
+			}
+			for _, tag := range devFile.Tags {
+				if matches(language.Frameworks, tag) {
+					score += FRAMEWORK_WEIGHT
+				}
+				if matches(language.Tools, tag) {
+					score += TOOL_WEIGHT
+				}
+			}
+		}
+		if score > scoreTarget {
+			scoreTarget = score
+			devfileTarget = devFile
+		}
+	}
+
+	if scoreTarget == 0 {
+		return devfileTarget, errors.New("No valid devfile found for current language " + language.Name)
+	}
+	return devfileTarget, nil
+}
+
+func matches(values []string, valueToFind string) bool {
+	for _, value := range values {
+		if strings.EqualFold(value, valueToFind) {
+			return true
+		}
+	}
+	return false
+}

--- a/go/test/apis/devfile_recognizer_test.go
+++ b/go/test/apis/devfile_recognizer_test.go
@@ -1,0 +1,122 @@
+package recognizer
+
+/*******************************************************************************
+ * Copyright (c) 2022 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc.
+ ******************************************************************************/
+import (
+	"testing"
+
+	"github.com/redhat-developer/alizer/pkg/apis/recognizer"
+)
+
+func TestDetectQuarkusDevfile(t *testing.T) {
+	detectDevFile(t, "quarkus", "java-quarkus")
+}
+
+func TestDetectMicronautDevfile(t *testing.T) {
+	detectDevFile(t, "micronaut", "java-maven")
+}
+
+func TestDetectNodeJSDevfile(t *testing.T) {
+	detectDevFile(t, "nodejs-ex", "nodejs")
+}
+
+func TestDetectDjangoDevfile(t *testing.T) {
+	detectDevFile(t, "django", "python-django")
+}
+
+func detectDevFile(t *testing.T, projectName string, devFileName string) {
+	devFileTypes := getDevFileTypes()
+
+	testingProjectPath := GetTestProjectPath(projectName)
+
+	devFileType, err := recognizer.SelectDevFileFromTypes(testingProjectPath, devFileTypes)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if devFileType.Name != devFileName {
+		t.Error("Expected value " + devFileName + " but it was" + devFileType.Name)
+	}
+}
+
+func getDevFileTypes() []recognizer.DevFileType {
+	return []recognizer.DevFileType{
+		{
+			Name:        "java",
+			Language:    "java",
+			ProjectType: "java",
+			Tags:        make([]string, 0),
+		},
+		{
+			Name:        "java-quarkus",
+			Language:    "java",
+			ProjectType: "quarkus",
+			Tags: []string{
+				"Java",
+				"Quarkus",
+			},
+		},
+		{
+			Name:        "java-maven",
+			Language:    "java",
+			ProjectType: "java",
+			Tags: []string{
+				"Java",
+				"Maven",
+			},
+		},
+		{
+			Name:        "java-spring",
+			Language:    "java",
+			ProjectType: "spring",
+			Tags: []string{
+				"Java",
+				"Spring",
+			},
+		},
+		{
+			Name:        "java-vertx",
+			Language:    "java",
+			ProjectType: "vertx",
+			Tags: []string{
+				"Java",
+				"Vert.x",
+			},
+		},
+		{
+			Name:        "java-wildfly",
+			Language:    "java",
+			ProjectType: "wildfly",
+			Tags: []string{
+				"Java",
+				"Wildfly",
+			},
+		},
+		{
+			Name:        "nodejs",
+			Language:    "nodejs",
+			ProjectType: "nodejs",
+			Tags: []string{
+				"NodeJS",
+				"Express",
+			},
+		},
+		{
+			Name:        "python-django",
+			Language:    "python",
+			ProjectType: "django",
+			Tags: []string{
+				"Python",
+				"pip",
+			},
+		},
+	}
+}

--- a/go/test/apis/language_recognizer_test.go
+++ b/go/test/apis/language_recognizer_test.go
@@ -37,7 +37,7 @@ func TestAnalyzeOnDjango(t *testing.T) {
 }
 
 func isLanguageInProject(t *testing.T, project string, wantedLanguage string, wantedTools []string, wantedFrameworks []string) {
-	testingProjectPath := getTestProjectPath(project)
+	testingProjectPath := GetTestProjectPath(project)
 
 	languages, err := recognizer.Analyze(testingProjectPath)
 	if err != nil {
@@ -94,7 +94,7 @@ func hasWantedTool(language language.Language, wantedTool string) bool {
 	return false
 }
 
-func getTestProjectPath(folder string) string {
+func GetTestProjectPath(folder string) string {
 	_, b, _, _ := runtime.Caller(0)
 	basepath := filepath.Dir(b)
 	return filepath.Join(basepath, "..", "..", "..", "resources/projects", folder)


### PR DESCRIPTION
This adds the basic devfile detection we have in java. It takes a list of devfile and return the one that matches the most.

@kadel for your use case do you prefer to send a registry url to alizer and receive the selected devfile or you will use this method (sending a list of devfiles and have the one that matches the most returned)? 
