### PR TITLE
feat: add .net detection in go impl (#72)

### DIFF
--- a/go/pkg/apis/enricher/dotnet_enricher.go
+++ b/go/pkg/apis/enricher/dotnet_enricher.go
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc.
+ ******************************************************************************/
+package recognizer
+
+import (
+	framework "github.com/redhat-developer/alizer/go/pkg/apis/enricher/framework/dotnet"
+	"github.com/redhat-developer/alizer/go/pkg/apis/language"
+	utils "github.com/redhat-developer/alizer/go/pkg/utils"
+)
+
+type DotNetEnricher struct{}
+
+func (j DotNetEnricher) GetSupportedLanguages() []string {
+	return []string{"c#", "f#", "visual basic .net"}
+}
+
+func getDotNetFrameworkDetectors() []FrameworkDetectorWithConfigFile {
+	return []FrameworkDetectorWithConfigFile{
+		&framework.DotNetDetector{},
+	}
+}
+
+func (j DotNetEnricher) DoEnrichLanguage(language *language.Language, files *[]string) {
+	configFiles := utils.GetFilesByRegex(files, ".*\\.\\w+proj")
+	for _, configFile := range configFiles {
+		getDotNetFrameworks(language, configFile)
+	}
+}
+
+func getDotNetFrameworks(language *language.Language, configFile string) {
+	for _, detector := range getDotNetFrameworkDetectors() {
+		detector.DoFrameworkDetection(language, configFile)
+	}
+}

--- a/go/pkg/apis/enricher/enricher.go
+++ b/go/pkg/apis/enricher/enricher.go
@@ -34,6 +34,7 @@ func getEnrichers() []Enricher {
 		&JavaEnricher{},
 		&JavaScriptEnricher{},
 		&PythonEnricher{},
+		&DotNetEnricher{},
 	}
 }
 
@@ -48,7 +49,7 @@ func GetEnricherByLanguage(language *language.Language) Enricher {
 
 func isLanguageSupportedByEnricher(nameLanguage string, enricher Enricher) bool {
 	for _, language := range enricher.GetSupportedLanguages() {
-		if strings.ToLower(language) == strings.ToLower(nameLanguage) {
+		if strings.EqualFold(language, nameLanguage) {
 			return true
 		}
 	}

--- a/go/pkg/apis/enricher/framework/dotnet/dotnet_detector.go
+++ b/go/pkg/apis/enricher/framework/dotnet/dotnet_detector.go
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc.
+ ******************************************************************************/
+package recognizer
+
+import (
+	"encoding/xml"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	"github.com/redhat-developer/alizer/go/pkg/apis/language"
+	"github.com/redhat-developer/alizer/go/pkg/schema"
+	"github.com/redhat-developer/alizer/go/pkg/utils"
+)
+
+type DotNetDetector struct{}
+
+func (m DotNetDetector) DoFrameworkDetection(language *language.Language, configFilePath string) {
+	framework := getFrameworks(configFilePath)
+	if framework == "" {
+		return
+	}
+	var frameworks []string
+	if strings.Contains(framework, ";") {
+		frameworks = strings.Split(framework, ";")
+	} else {
+		frameworks = []string{framework}
+	}
+
+	for _, frm := range frameworks {
+		if !utils.Contains(language.Frameworks, frm) {
+			language.Frameworks = append(language.Frameworks, frm)
+		}
+	}
+}
+
+func getFrameworks(configFilePath string) string {
+	xmlFile, err := os.Open(configFilePath)
+	if err != nil {
+		return ""
+	}
+	byteValue, _ := ioutil.ReadAll(xmlFile)
+
+	var proj schema.DotNetProject
+	xml.Unmarshal(byteValue, &proj)
+
+	defer xmlFile.Close()
+	if proj.PropertyGroup.TargetFramework != "" {
+		return proj.PropertyGroup.TargetFramework
+	} else if proj.PropertyGroup.TargetFrameworkVersion != "" {
+		return proj.PropertyGroup.TargetFrameworkVersion
+	} else if proj.PropertyGroup.TargetFrameworks != "" {
+		return proj.PropertyGroup.TargetFrameworks
+	}
+	return ""
+}

--- a/go/pkg/schema/dotnet_proj.go
+++ b/go/pkg/schema/dotnet_proj.go
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc.
+ ******************************************************************************/
+package schema
+
+type DotNetProject struct {
+	PropertyGroup struct {
+		TargetFramework        string `xml:"TargetFramework"`
+		TargetFrameworkVersion string `xml:"TargetFrameworkVersion"`
+		TargetFrameworks       string `xml:"TargetFrameworks"`
+	} `xml:"PropertyGroup"`
+}

--- a/go/pkg/utils/detector.go
+++ b/go/pkg/utils/detector.go
@@ -16,10 +16,27 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/redhat-developer/alizer/go/pkg/schema"
 )
+
+func GetFilesByRegex(filePaths *[]string, regexFile string) []string {
+	matchedPaths := []string{}
+	for _, path := range *filePaths {
+		if isPathOfWantedRegex(path, regexFile) {
+			matchedPaths = append(matchedPaths, path)
+		}
+	}
+	return matchedPaths
+}
+
+func isPathOfWantedRegex(path string, regexFile string) bool {
+	_, file := filepath.Split(path)
+	matched, _ := regexp.MatchString(regexFile, file)
+	return matched
+}
 
 func GetFile(filePaths *[]string, wantedFile string) string {
 	for _, path := range *filePaths {
@@ -41,7 +58,7 @@ func HasFile(files *[]string, wantedFile string) bool {
 
 func IsPathOfWantedFile(path string, wantedFile string) bool {
 	_, file := filepath.Split(path)
-	return file == wantedFile
+	return strings.EqualFold(file, wantedFile)
 }
 
 func IsTagInFile(file string, tag string) bool {
@@ -97,4 +114,14 @@ func AddToArrayIfValueExist(arr *[]string, val string) {
 	if val != "" {
 		*arr = append(*arr, val)
 	}
+}
+
+func Contains(s []string, str string) bool {
+	for _, v := range s {
+		if v == str {
+			return true
+		}
+	}
+
+	return false
 }

--- a/go/pkg/utils/langfiles/resources/languages-customization.yml
+++ b/go/pkg/utils/langfiles/resources/languages-customization.yml
@@ -1,3 +1,17 @@
+C#:
+  aliases:
+    - "dotnet"
+  configuration_files:
+    - ".*\\.\\w+proj"
+    - "appsettings.json"
+  component: true
+F#:
+  aliases:
+    - "dotnet"
+  configuration_files:
+    - ".*\\.\\w+proj"
+    - "appsettings.json"
+  component: true
 Go:
   configuration_files:
     - "go.mod"
@@ -19,4 +33,11 @@ Python:
 Rust:
   configuration_files:
     - "Cargo.toml"
+  component: true
+Visual Basic .NET:
+  aliases:
+    - "dotnet"
+  configuration_files:
+    - ".*\\.\\w+proj"
+    - "appsettings.json"
   component: true

--- a/go/test/apis/language_recognizer_test.go
+++ b/go/test/apis/language_recognizer_test.go
@@ -36,6 +36,18 @@ func TestAnalyzeOnDjango(t *testing.T) {
 	isLanguageInProject(t, "django", "python", []string{}, []string{"django"})
 }
 
+func TestAnalyzeOnCSharp(t *testing.T) {
+	isLanguageInProject(t, "s2i-dotnetcore-ex", "c#", []string{}, []string{"net6.0"})
+}
+
+func TestAnalyzeOnFSharp(t *testing.T) {
+	isLanguageInProject(t, "net-fsharp", "f#", []string{}, []string{"netcoreapp3.1"})
+}
+
+func TestAnalyzeOnVBNET(t *testing.T) {
+	isLanguageInProject(t, "net-vb", "visual basic .net", []string{}, []string{"netcoreapp3.1"})
+}
+
 func isLanguageInProject(t *testing.T, project string, wantedLanguage string, wantedTools []string, wantedFrameworks []string) {
 	testingProjectPath := GetTestProjectPath(project)
 


### PR DESCRIPTION
it resolves #72 

This does not contain tests for devfiles as the devfile algorithm needs to use component detection to avoid wrong results and component detection is still on-going #64