### PR TITLE
feat: pick devfile based on component detection and remove framework constraint

### DIFF
--- a/go/pkg/apis/enricher/go_enricher.go
+++ b/go/pkg/apis/enricher/go_enricher.go
@@ -49,7 +49,9 @@ func (j GoEnricher) DoEnrichLanguage(language *language.Language, files *[]strin
 		if err != nil {
 			return
 		}
-		language.Tools = []string{goModFile.Go.Version}
+		if goModFile.Go != nil {
+			language.Tools = []string{goModFile.Go.Version}
+		}
 		detectGoFrameworks(language, goModFile)
 	}
 }

--- a/go/pkg/apis/recognizer/component_recognizer.go
+++ b/go/pkg/apis/recognizer/component_recognizer.go
@@ -59,11 +59,11 @@ func DetectComponents(path string) ([]Component, error) {
 }
 
 /*
-	 getComponentsWithoutConfigFile retrieves the components which are written with a language that does not require a config file
-	 Parameters:
-		 directories: list of directories to analyze
-	 Returns:
-		 components found
+	getComponentsWithoutConfigFile retrieves the components which are written with a language that does not require a config file
+	Parameters:
+		directories: list of directories to analyze
+	Returns:
+		components found
 */
 func getComponentsWithoutConfigFile(directories []string) []Component {
 	var components []Component
@@ -77,11 +77,11 @@ func getComponentsWithoutConfigFile(directories []string) []Component {
 }
 
 /*
-	 isLangForNoConfigComponent verify if main language requires any config file
-	 Parameters:
-		 component:
-	 Returns:
-		 bool: true if language does not require any config file
+	isLangForNoConfigComponent verify if main language requires any config file
+	Parameters:
+		component:
+	Returns:
+		bool: true if language does not require any config file
 */
 func isLangForNoConfigComponent(languages []language.Language) bool {
 	if len(languages) == 0 {
@@ -97,12 +97,12 @@ func isLangForNoConfigComponent(languages []language.Language) bool {
 }
 
 /*
-	 getDirectoriesPathsWithoutConfigFile retrieves all directories that do not contain any Component
-	 Parameters:
-		 root: root folder where to start the search
-		 components: list of components already detected
-	 Returns:
-		 list of directories path that does not contain any component
+	getDirectoriesPathsWithoutConfigFile retrieves all directories that do not contain any Component
+	Parameters:
+		root: root folder where to start the search
+		components: list of components already detected
+	Returns:
+		list of directories path that does not contain any component
 */
 func getDirectoriesWithoutConfigFile(root string, components []Component) []string {
 	if len(components) == 0 {
@@ -121,15 +121,16 @@ func getDirectoriesWithoutConfigFile(root string, components []Component) []stri
 	return directories
 }
 
-/**
- * Return all paths which are not sub-folders of some other path within the list
- * Target will be added to the list if it is not a sub-folder of any other path within the list
- * If a path in the list is sub-folder of Target, that path will be removed.
- *
- * @param target new path to be added
- * @param directories list of all previously added paths
- * @return the list containing all paths which are not sub-folders of any other
- */
+/*
+	getParentFolders return all paths which are not sub-folders of some other path within the list
+	Target will be added to the list if it is not a sub-folder of any other path within the list
+	If a path in the list is sub-folder of Target, that path will be removed.
+	Parameters:
+		target: new path to be added
+		directories: list of all previously added paths
+	Returns:
+		the list containing all paths which are not sub-folders of any other
+*/
 func getParentFolders(target string, directories []string) []string {
 	updatedDirectories := []string{}
 	for _, dir := range directories {
@@ -148,12 +149,12 @@ func getParentFolders(target string, directories []string) []string {
 }
 
 /*
-	 isAnyComponentInPath checks if a component is present in path
-	 Parameters:
-		 path: path where to search for component
-		 components: list of components
-	 Returns:
-		 true if a component is found starting from path
+	isAnyComponentInPath checks if a component is present in path
+	Parameters:
+		path: path where to search for component
+		components: list of components
+	Returns:
+		true if a component is found starting from path
 */
 func isAnyComponentInPath(path string, components []Component) bool {
 	for _, component := range components {
@@ -165,23 +166,23 @@ func isAnyComponentInPath(path string, components []Component) bool {
 }
 
 /*
-	 isFirstPathParentOfSecond check if first path is parent (direct or not) of second path
-	 Parameters:
-		 firstPath: path to be used as parent
-		 secondPath: path to be used as child
-	 Returns:
-		 true if firstPath is part of secondPath
+	isFirstPathParentOfSecond check if first path is parent (direct or not) of second path
+	Parameters:
+		firstPath: path to be used as parent
+		secondPath: path to be used as child
+	Returns:
+		true if firstPath is part of secondPath
 */
 func isFirstPathParentOfSecond(firstPath string, secondPath string) bool {
 	return strings.Contains(secondPath, firstPath)
 }
 
 /*
-	 detectComponents detect components by analyzing all files
-	 Parameters:
-		 files: list of files to analyze
-	 Returns:
-		 list of components detected or err if any error occurs
+	detectComponents detect components by analyzing all files
+	Parameters:
+		files: list of files to analyze
+	Returns:
+		list of components detected or err if any error occurs
 */
 func detectComponents(files []string) ([]Component, error) {
 	configurationPerLanguage := langfiles.Get().GetConfigurationPerLanguageMapping()
@@ -224,14 +225,14 @@ func getLanguagesByConfigurationFile(configurationPerLanguage map[string][]strin
 }
 
 /*
-	 detectComponent returns a Component if found:
-							 - language must be enabled for component detection
-					 , error otherwise
-	 Parameters:
-		 root: path to be used as root where to start the detection
-		 configLanguages: languages associated to the config file found and to be used as target for detection
-	 Returns:
-		 component detected or error if any error occurs
+	detectComponent returns a Component if found:
+							- language must be enabled for component detection
+					, error otherwise
+	Parameters:
+		root: path to be used as root where to start the detection
+		configLanguages: languages associated to the config file found and to be used as target for detection
+	Returns:
+		component detected or error if any error occurs
 */
 func detectComponent(root string, configLanguages []string) (Component, error) {
 	languages, err := Analyze(root)
@@ -253,13 +254,13 @@ func detectComponent(root string, configLanguages []string) (Component, error) {
 }
 
 /*
-	 getLanguagesWeightedByConfigFile returns the list of languages reordered by importance per config file.
-									  Language found by analyzing the config file is used as target.
-	 Parameters:
-		 languages: list of languages to be reordered
-		 configLanguages: languages associated to the config file found and to be used as target languages
-	 Returns:
-		 list of languages reordered
+	getLanguagesWeightedByConfigFile returns the list of languages reordered by importance per config file.
+									Language found by analyzing the config file is used as target.
+	Parameters:
+		languages: list of languages to be reordered
+		configLanguages: languages associated to the config file found and to be used as target languages
+	Returns:
+		list of languages reordered
 */
 func getLanguagesWeightedByConfigFile(languages []language.Language, configLanguages []string) []language.Language {
 	if len(configLanguages) == 0 {

--- a/go/pkg/apis/recognizer/component_recognizer.go
+++ b/go/pkg/apis/recognizer/component_recognizer.go
@@ -189,6 +189,9 @@ func detectComponents(files []string) ([]Component, error) {
 	var components []Component
 	for _, file := range files {
 		dir, fileName := filepath.Split(file)
+		if dir == "" {
+			dir = "./"
+		}
 		languages, err := getLanguagesByConfigurationFile(configurationPerLanguage, fileName)
 		if err != nil {
 			continue

--- a/go/pkg/apis/recognizer/component_recognizer.go
+++ b/go/pkg/apis/recognizer/component_recognizer.go
@@ -11,8 +11,10 @@
 package recognizer
 
 import (
+	"errors"
 	"io/fs"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	enricher "github.com/redhat-developer/alizer/go/pkg/apis/enricher"
@@ -25,8 +27,21 @@ type Component struct {
 	Languages []language.Language
 }
 
+func DetectComponentsInRoot(path string) ([]Component, error) {
+	files, err := getFilePathsInRoot(path)
+	if err != nil {
+		return []Component{}, err
+	}
+	components, err := detectComponents(files)
+	if err != nil {
+		return []Component{}, err
+	}
+
+	return components, nil
+}
+
 func DetectComponents(path string) ([]Component, error) {
-	files, err := getFilePaths(path)
+	files, err := getFilePathsFromRoot(path)
 	if err != nil {
 		return []Component{}, err
 	}
@@ -44,16 +59,16 @@ func DetectComponents(path string) ([]Component, error) {
 }
 
 /*
-	getComponentsWithoutConfigFile retrieves the components which are written with a language that does not require a config file
-	Parameters:
-		directories: list of directories to analyze
-	Returns:
-		components found
+	 getComponentsWithoutConfigFile retrieves the components which are written with a language that does not require a config file
+	 Parameters:
+		 directories: list of directories to analyze
+	 Returns:
+		 components found
 */
 func getComponentsWithoutConfigFile(directories []string) []Component {
 	var components []Component
 	for _, dir := range directories {
-		component, _ := detectComponent(dir, "")
+		component, _ := detectComponent(dir, []string{})
 		if component.Path != "" && isLangForNoConfigComponent(component.Languages) {
 			components = append(components, component)
 		}
@@ -62,11 +77,11 @@ func getComponentsWithoutConfigFile(directories []string) []Component {
 }
 
 /*
-	isLangForNoConfigComponent verify if main language requires any config file
-	Parameters:
-		component:
-	Returns:
-		bool: true if language does not require any config file
+	 isLangForNoConfigComponent verify if main language requires any config file
+	 Parameters:
+		 component:
+	 Returns:
+		 bool: true if language does not require any config file
 */
 func isLangForNoConfigComponent(languages []language.Language) bool {
 	if len(languages) == 0 {
@@ -82,12 +97,12 @@ func isLangForNoConfigComponent(languages []language.Language) bool {
 }
 
 /*
-	getDirectoriesPathsWithoutConfigFile retrieves all directories that do not contain any Component
-	Parameters:
-		root: root folder where to start the search
-		components: list of components already detected
-	Returns:
-		list of directories path that does not contain any component
+	 getDirectoriesPathsWithoutConfigFile retrieves all directories that do not contain any Component
+	 Parameters:
+		 root: root folder where to start the search
+		 components: list of components already detected
+	 Returns:
+		 list of directories path that does not contain any component
 */
 func getDirectoriesWithoutConfigFile(root string, components []Component) []string {
 	if len(components) == 0 {
@@ -107,13 +122,13 @@ func getDirectoriesWithoutConfigFile(root string, components []Component) []stri
 }
 
 /**
-* Return all paths which are not sub-folders of some other path within the list
-* Target will be added to the list if it is not a sub-folder of any other path within the list
-* If a path in the list is sub-folder of Target, that path will be removed.
-*
-* @param target new path to be added
-* @param directories list of all previously added paths
-* @return the list containing all paths which are not sub-folders of any other
+ * Return all paths which are not sub-folders of some other path within the list
+ * Target will be added to the list if it is not a sub-folder of any other path within the list
+ * If a path in the list is sub-folder of Target, that path will be removed.
+ *
+ * @param target new path to be added
+ * @param directories list of all previously added paths
+ * @return the list containing all paths which are not sub-folders of any other
  */
 func getParentFolders(target string, directories []string) []string {
 	updatedDirectories := []string{}
@@ -133,12 +148,12 @@ func getParentFolders(target string, directories []string) []string {
 }
 
 /*
-	isAnyComponentInPath checks if a component is present in path
-	Parameters:
-		path: path where to search for component
-		components: list of components
-	Returns:
-		true if a component is found starting from path
+	 isAnyComponentInPath checks if a component is present in path
+	 Parameters:
+		 path: path where to search for component
+		 components: list of components
+	 Returns:
+		 true if a component is found starting from path
 */
 func isAnyComponentInPath(path string, components []Component) bool {
 	for _, component := range components {
@@ -150,61 +165,82 @@ func isAnyComponentInPath(path string, components []Component) bool {
 }
 
 /*
-	isFirstPathParentOfSecond check if first path is parent (direct or not) of second path
-	Parameters:
-		firstPath: path to be used as parent
-		secondPath: path to be used as child
-	Returns:
-		true if firstPath is part of secondPath
+	 isFirstPathParentOfSecond check if first path is parent (direct or not) of second path
+	 Parameters:
+		 firstPath: path to be used as parent
+		 secondPath: path to be used as child
+	 Returns:
+		 true if firstPath is part of secondPath
 */
 func isFirstPathParentOfSecond(firstPath string, secondPath string) bool {
 	return strings.Contains(secondPath, firstPath)
 }
 
 /*
-	detectComponents detect components by analyzing all files
-	Parameters:
-		files: list of files to analyze
-	Returns:
-		list of components detected or err if any error occurs
+	 detectComponents detect components by analyzing all files
+	 Parameters:
+		 files: list of files to analyze
+	 Returns:
+		 list of components detected or err if any error occurs
 */
 func detectComponents(files []string) ([]Component, error) {
 	configurationPerLanguage := langfiles.Get().GetConfigurationPerLanguageMapping()
 	var components []Component
 	for _, file := range files {
 		dir, fileName := filepath.Split(file)
-		if language, isConfig := configurationPerLanguage[fileName]; isConfig && isConfigurationValid(language, file) {
-			component, err := detectComponent(dir, language)
-			if err != nil {
-				return []Component{}, err
-			}
-			if component.Path != "" {
-				components = append(components, component)
+		languages, err := getLanguagesByConfigurationFile(configurationPerLanguage, fileName)
+		if err != nil {
+			continue
+		}
+		for _, language := range languages {
+			if isConfigurationValid(language, file) {
+				component, _ := detectComponent(dir, languages)
+				if component.Path != "" {
+					components = appendIfMissing(components, component)
+					break
+				}
 			}
 		}
 	}
 	return components, nil
 }
 
+func appendIfMissing(components []Component, component Component) []Component {
+	for _, comp := range components {
+		if strings.EqualFold(comp.Path, component.Path) {
+			return components
+		}
+	}
+	return append(components, component)
+}
+
+func getLanguagesByConfigurationFile(configurationPerLanguage map[string][]string, file string) ([]string, error) {
+	for regex, languages := range configurationPerLanguage {
+		if match, _ := regexp.MatchString(regex, file); match {
+			return languages, nil
+		}
+	}
+	return nil, errors.New("no languages found for configuration file " + file)
+}
+
 /*
-	detectComponent returns a Component if found:
-							- language must be enabled for component detection
-							- there should be at least one framework detected
-					, error otherwise
-	Parameters:
-		root: path to be used as root where to start the detection
-		language: language to be used as target for detection
-	Returns:
-		component detected or error if any error occurs
+	 detectComponent returns a Component if found:
+							 - language must be enabled for component detection
+					 , error otherwise
+	 Parameters:
+		 root: path to be used as root where to start the detection
+		 configLanguages: languages associated to the config file found and to be used as target for detection
+	 Returns:
+		 component detected or error if any error occurs
 */
-func detectComponent(root string, language string) (Component, error) {
+func detectComponent(root string, configLanguages []string) (Component, error) {
 	languages, err := Analyze(root)
 	if err != nil {
 		return Component{}, err
 	}
-	languages = getLanguagesWeightedByConfigFile(languages, language)
+	languages = getLanguagesWeightedByConfigFile(languages, configLanguages)
 	if len(languages) > 0 {
-		if mainLang := languages[0]; mainLang.CanBeComponent && len(mainLang.Frameworks) > 0 {
+		if mainLang := languages[0]; mainLang.CanBeComponent {
 			return Component{
 				Path:      root,
 				Languages: languages,
@@ -217,23 +253,25 @@ func detectComponent(root string, language string) (Component, error) {
 }
 
 /*
-	getLanguagesWeightedByConfigFile returns the list of languages reordered by importance per config file.
-									 Language found by analyzing the config file is used as target.
-	Parameters:
-		languages: list of languages to be reordered
-		languageByConfig: target language
-	Returns:
-		list of languages reordered
+	 getLanguagesWeightedByConfigFile returns the list of languages reordered by importance per config file.
+									  Language found by analyzing the config file is used as target.
+	 Parameters:
+		 languages: list of languages to be reordered
+		 configLanguages: languages associated to the config file found and to be used as target languages
+	 Returns:
+		 list of languages reordered
 */
-func getLanguagesWeightedByConfigFile(languages []language.Language, languageByConfig string) []language.Language {
-	if languageByConfig == "" {
+func getLanguagesWeightedByConfigFile(languages []language.Language, configLanguages []string) []language.Language {
+	if len(configLanguages) == 0 {
 		return languages
 	}
 
 	for index, lang := range languages {
-		if strings.EqualFold(lang.Name, languageByConfig) {
-			sliceWithoutLang := append(languages[:index], languages[index+1:]...)
-			return append([]language.Language{lang}, sliceWithoutLang...)
+		for _, configLanguage := range configLanguages {
+			if strings.EqualFold(lang.Name, configLanguage) {
+				sliceWithoutLang := append(languages[:index], languages[index+1:]...)
+				return append([]language.Language{lang}, sliceWithoutLang...)
+			}
 		}
 	}
 	return languages

--- a/go/pkg/apis/recognizer/devfile_recognizer.go
+++ b/go/pkg/apis/recognizer/devfile_recognizer.go
@@ -25,6 +25,22 @@ type DevFileType struct {
 }
 
 func SelectDevFileFromTypes(path string, devFileTypes []DevFileType) (DevFileType, error) {
+	components, _ := DetectComponentsInRoot(path)
+	if len(components) > 0 {
+		devfile, err := selectDevFileByLanguage(components[0].Languages[0], devFileTypes)
+		if err == nil {
+			return devfile, nil
+		}
+	}
+
+	components, _ = DetectComponents(path)
+	if len(components) > 0 {
+		devfile, err := selectDevFileByLanguage(components[0].Languages[0], devFileTypes)
+		if err == nil {
+			return devfile, nil
+		}
+	}
+
 	languages, err := Analyze(path)
 	if err != nil {
 		return DevFileType{}, err

--- a/go/pkg/apis/recognizer/devfile_recognizer.go
+++ b/go/pkg/apis/recognizer/devfile_recognizer.go
@@ -24,7 +24,7 @@ type DevFileType struct {
 	Tags        []string
 }
 
-func SelectDevFileFromTypes(path string, devFileTypes []DevFileType) (DevFileType, error) {
+func SelectDevFileFromTypes(path string, devFileTypes []DevFileType) (int, error) {
 	components, _ := DetectComponentsInRoot(path)
 	if len(components) > 0 {
 		devfile, err := selectDevFileByLanguage(components[0].Languages[0], devFileTypes)
@@ -43,31 +43,31 @@ func SelectDevFileFromTypes(path string, devFileTypes []DevFileType) (DevFileTyp
 
 	languages, err := Analyze(path)
 	if err != nil {
-		return DevFileType{}, err
+		return -1, err
 	}
 	devfile, err := SelectDevFileUsingLanguagesFromTypes(languages, devFileTypes)
 	if err != nil {
-		return DevFileType{}, errors.New("No valid devfile found for project in " + path)
+		return -1, errors.New("No valid devfile found for project in " + path)
 	}
 	return devfile, nil
 }
 
-func SelectDevFileUsingLanguagesFromTypes(languages []language.Language, devFileTypes []DevFileType) (DevFileType, error) {
+func SelectDevFileUsingLanguagesFromTypes(languages []language.Language, devFileTypes []DevFileType) (int, error) {
 	for _, language := range languages {
 		devfile, err := selectDevFileByLanguage(language, devFileTypes)
 		if err == nil {
 			return devfile, nil
 		}
 	}
-	return DevFileType{}, errors.New("no valid devfile found by using those languages")
+	return -1, errors.New("no valid devfile found by using those languages")
 }
 
-func selectDevFileByLanguage(language language.Language, devFileTypes []DevFileType) (DevFileType, error) {
+func selectDevFileByLanguage(language language.Language, devFileTypes []DevFileType) (int, error) {
 	scoreTarget := 0
-	devfileTarget := DevFileType{}
+	devfileTarget := -1
 	FRAMEWORK_WEIGHT := 10
 	TOOL_WEIGHT := 5
-	for _, devFile := range devFileTypes {
+	for index, devFile := range devFileTypes {
 		score := 0
 		if strings.EqualFold(devFile.Language, language.Name) || matches(language.Aliases, devFile.Language) {
 			score++
@@ -85,7 +85,7 @@ func selectDevFileByLanguage(language language.Language, devFileTypes []DevFileT
 		}
 		if score > scoreTarget {
 			scoreTarget = score
-			devfileTarget = devFile
+			devfileTarget = index
 		}
 	}
 

--- a/go/pkg/schema/languages.go
+++ b/go/pkg/schema/languages.go
@@ -30,6 +30,7 @@ type LanguageCustomization struct {
 	ConfigurationFiles []string `yaml:"configuration_files"`
 	Component          bool     `yaml:"component"`
 	ExcludeFolders     []string `yaml:"exclude_folders,omitempty"`
+	Aliases            []string `yaml:"aliases"`
 }
 
 type LanguagesCustomizations map[string]LanguageCustomization

--- a/go/pkg/utils/langfiles/languages_file_handler.go
+++ b/go/pkg/utils/langfiles/languages_file_handler.go
@@ -83,7 +83,24 @@ func customizeLanguage(languageItem *LanguageItem) {
 		(*languageItem).ConfigurationFiles = customization.ConfigurationFiles
 		(*languageItem).ExcludeFolders = customization.ExcludeFolders
 		(*languageItem).Component = customization.Component
+		(*languageItem).Aliases = appendSlice((*languageItem).Aliases, customization.Aliases)
 	}
+}
+
+func appendSlice(values []string, toBeAdded []string) []string {
+	for _, item := range toBeAdded {
+		values = appendIfMissing(values, item)
+	}
+	return values
+}
+
+func appendIfMissing(values []string, item string) []string {
+	for _, value := range values {
+		if strings.EqualFold(value, item) {
+			return values
+		}
+	}
+	return append(values, item)
 }
 
 func getLanguagesProperties() schema.LanguagesProperties {
@@ -140,12 +157,12 @@ func (l *LanguageFile) GetLanguageByNameOrAlias(name string) (LanguageItem, erro
 	return l.GetLanguageByAlias(name)
 }
 
-func (l *LanguageFile) GetConfigurationPerLanguageMapping() map[string]string {
-	configurationPerLanguage := make(map[string]string)
+func (l *LanguageFile) GetConfigurationPerLanguageMapping() map[string][]string {
+	configurationPerLanguage := make(map[string][]string)
 	for langName, langItem := range l.languages {
 		configurationFiles := langItem.ConfigurationFiles
 		for _, configFile := range configurationFiles {
-			configurationPerLanguage[configFile] = langName
+			configurationPerLanguage[configFile] = append(configurationPerLanguage[configFile], langName)
 		}
 	}
 	return configurationPerLanguage

--- a/go/test/apis/component_recognizer_test.go
+++ b/go/test/apis/component_recognizer_test.go
@@ -47,7 +47,7 @@ func TestComponentDetectionOnDoubleComponents(t *testing.T) {
 
 func TestComponentDetectionMultiProjects(t *testing.T) {
 	components := getComponentsFromProject(t, "")
-	nComps := 11
+	nComps := 13
 	if len(components) != nComps {
 		t.Errorf("Expected " + strconv.Itoa(nComps) + " components but found " + strconv.Itoa(len(components)))
 	}

--- a/go/test/apis/devfile_recognizer_test.go
+++ b/go/test/apis/devfile_recognizer_test.go
@@ -78,7 +78,7 @@ func TestDetectGoDevfile(t *testing.T) {
 }
 
 func detectDevFile(t *testing.T, projectName string, devFileName string) {
-	detectDevFileFunc := func(devFileTypes []recognizer.DevFileType) (recognizer.DevFileType, error) {
+	detectDevFileFunc := func(devFileTypes []recognizer.DevFileType) (int, error) {
 		testingProjectPath := GetTestProjectPath(projectName)
 		return recognizer.SelectDevFileFromTypes(testingProjectPath, devFileTypes)
 	}
@@ -94,21 +94,21 @@ func detectDevFileUsingLanguages(t *testing.T, projectName string, languages []l
 			t.Error(err)
 		}
 	}
-	detectDevFileFunc := func(devFileTypes []recognizer.DevFileType) (recognizer.DevFileType, error) {
+	detectDevFileFunc := func(devFileTypes []recognizer.DevFileType) (int, error) {
 		return recognizer.SelectDevFileUsingLanguagesFromTypes(languages, devFileTypes)
 	}
 	detectDevFileInner(t, devFileName, detectDevFileFunc)
 }
 
-func detectDevFileInner(t *testing.T, devFileName string, detectFuncInner func([]recognizer.DevFileType) (recognizer.DevFileType, error)) {
+func detectDevFileInner(t *testing.T, devFileName string, detectFuncInner func([]recognizer.DevFileType) (int, error)) {
 	devFileTypes := getDevFileTypes()
-	devFileType, err := detectFuncInner(devFileTypes)
+	devFileTarget, err := detectFuncInner(devFileTypes)
 	if err != nil {
 		t.Error(err)
 	}
 
-	if devFileType.Name != devFileName {
-		t.Error("Expected value " + devFileName + " but it was" + devFileType.Name)
+	if devFileTypes[devFileTarget].Name != devFileName {
+		t.Error("Expected value " + devFileName + " but it was" + devFileTypes[devFileTarget].Name)
 	}
 }
 


### PR DESCRIPTION
@kadel This PR should improve the detection as we discussed last time. You won't need to use analyze anymore (atleast i don't think it would be very useful for odo) but do component detection or select devfile directly.

So now what we have is:
**analyze** -> just perform an analysis of all files from the root. It just gives an overview of what's inside the root
**component detection** -> it detects components within the root. If there is a component living in the root it will be in first position of the returned list. If you want infos about the languages used by a component you should use the languages field of the component itself. First language in the list is the main one.
**devfile detection** -> tries to detect a component in the root and return a devfile for it. If there is no component, it start looking for some components withing the sub-folders. If there are none, it uses the outcome of analyze.