### PR TITLE
refactor: change how component detection works with config file

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -52,7 +52,10 @@ and it consists of two steps:
 1) Detect languages which have a configuration file such as Java (`pom.xml`, `build.gradle`)
 2) Detect languages which may not have a configuration file such as Python
 
-Alizer scans all files in the source tree to find out a configuration file. If found and the language detected is enabled (belong to the list above) a component is said to be found starting from that path. Only one component per path is possible. This step gets repeated for all configuration files present in the source tree which live into different paths.
+Alizer scans all files in the source tree to find out a configuration file. If found and the language associated to it (e.g pom.xml -> JAVA) is enabled (belong to the list above) a component is said to be found starting from that path. Only one component per path is possible. This step gets repeated for all configuration files present in the source tree which live into different paths.
+
+To speed up the detection only the language associated to the configuration file is analyzed. If a configuration file can be associated to multiple languages (e.g. `.proj` can be part of either a C# or F# or VB.NET project) then a deep analysis is made.
+
 Once the first step ends up, if there are no other free subfolders (free = folders that do not belong to any component) the second step is skipped otherwise Alizer tries to search for a component written with a language which may not have a configuration file. In that subfolder a simple Language detection is performed and the first language is taken into account for further calculations. 
 
 The result is a list of components where each component consists of:

--- a/go/pkg/apis/recognizer/component_recognizer.go
+++ b/go/pkg/apis/recognizer/component_recognizer.go
@@ -246,12 +246,14 @@ func detectComponentByAnalyzingConfigFile(file string, mainLang string) (model.C
 	if err != nil {
 		return model.Component{}, err
 	}
-	return model.Component{
+	component := model.Component{
 		Path: dir,
 		Languages: []model.Language{
 			lang,
 		},
-	}, nil
+	}
+	enrichComponent(&component)
+	return component, nil
 }
 
 func detectComponentUsingConfigFile(file string, languages []string) (model.Component, error) {

--- a/go/pkg/apis/recognizer/component_recognizer.go
+++ b/go/pkg/apis/recognizer/component_recognizer.go
@@ -237,12 +237,12 @@ func detectComponentByFolderAnalysis(root string, configLanguages []string) (mod
 
 }
 
-func detectComponentByAnalyzingConfigFile(file string, language string) (model.Component, error) {
-	if !isConfigurationValid(language, file) {
+func detectComponentByAnalyzingConfigFile(file string, mainLang string) (model.Component, error) {
+	if !isConfigurationValid(mainLang, file) {
 		return model.Component{}, errors.New("language not valid for component detection")
 	}
 	dir, _ := utils.NormalizeSplit(file)
-	lang, err := AnalyzeFile(file, language)
+	lang, err := AnalyzeFile(file, mainLang)
 	if err != nil {
 		return model.Component{}, err
 	}

--- a/go/pkg/apis/recognizer/language_recognizer.go
+++ b/go/pkg/apis/recognizer/language_recognizer.go
@@ -107,6 +107,7 @@ func AnalyzeFile(configFile string, targetLanguage string) (model.Language, erro
 		Aliases:        lang.Aliases,
 		Frameworks:     []string{},
 		Tools:          []string{},
+		Weight:         100,
 		CanBeComponent: true}
 	langEnricher := enricher.GetEnricherByLanguage(targetLanguage)
 	if langEnricher != nil {

--- a/go/pkg/apis/recognizer/language_recognizer.go
+++ b/go/pkg/apis/recognizer/language_recognizer.go
@@ -97,6 +97,24 @@ func Analyze(path string) ([]model.Language, error) {
 	return languagesFound, nil
 }
 
+func AnalyzeFile(configFile string, targetLanguage string) (model.Language, error) {
+	lang, err := langfile.Get().GetLanguageByName(targetLanguage)
+	if err != nil {
+		return model.Language{}, err
+	}
+	tmpLanguage := model.Language{
+		Name:           lang.Name,
+		Aliases:        lang.Aliases,
+		Frameworks:     []string{},
+		Tools:          []string{},
+		CanBeComponent: true}
+	langEnricher := enricher.GetEnricherByLanguage(targetLanguage)
+	if langEnricher != nil {
+		langEnricher.DoEnrichLanguage(&tmpLanguage, &[]string{configFile})
+	}
+	return tmpLanguage, nil
+}
+
 func extractExtensions(paths []string) map[string]int {
 	extensions := make(map[string]int)
 	for _, path := range paths {

--- a/go/pkg/utils/detector.go
+++ b/go/pkg/utils/detector.go
@@ -138,3 +138,11 @@ func Contains(s []string, str string) bool {
 
 	return false
 }
+
+func NormalizeSplit(file string) (string, string) {
+	dir, fileName := filepath.Split(file)
+	if dir == "" {
+		dir = "./"
+	}
+	return dir, fileName
+}

--- a/go/test/apis/component_recognizer_test.go
+++ b/go/test/apis/component_recognizer_test.go
@@ -33,6 +33,18 @@ func TestComponentDetectionOnJavascript(t *testing.T) {
 	isComponentsInProject(t, "nodejs-ex", 1, "javascript", "nodejs-starter")
 }
 
+func TestComponentDetectionOnDotNet(t *testing.T) {
+	isComponentsInProject(t, "s2i-dotnetcore-ex", 1, "c#")
+}
+
+func TestComponentDetectionOnFSharp(t *testing.T) {
+	isComponentsInProject(t, "net-fsharp", 1, "f#")
+}
+
+func TestComponentDetectionOnVBNet(t *testing.T) {
+	isComponentsInProject(t, "net-vb", 1, "Visual Basic .NET")
+}
+
 func TestComponentDetectionOnDjango(t *testing.T) {
 	isComponentsInProject(t, "django", 1, "python", "django")
 }

--- a/go/test/apis/component_recognizer_test.go
+++ b/go/test/apis/component_recognizer_test.go
@@ -128,12 +128,7 @@ func getComponentsFromProject(t *testing.T, project string) []model.Component {
 }
 
 func getComponentsFromFiles(t *testing.T, files []string) []model.Component {
-	components, err := recognizer.DetectComponentsFromFilesList(files)
-	if err != nil {
-		t.Error(err)
-	}
-
-	return components
+	return recognizer.DetectComponentsFromFilesList(files)
 }
 
 func isComponentsInProject(t *testing.T, project string, expectedNumber int, expectedLanguage string, expectedProjectName string) {


### PR DESCRIPTION
@kadel @jeffmaury this patch changes a bit the behavior of component detection and it improves performances in some specific cases.

Basically, Alizer in main branch always perform a deep analysis to detect all languages starting from a folder where it thinks a component may live (= where a config file is found, e.g. a `pom.xml`)
So there are 2 possible cases which always perform a deep analysis: 
1) a pom.xml (or any other config file) is in folder -> a component lives here, Alizer finds all languages that are part of the component/folder -> return the component {path, languages}
2) no config file is found in folder -> Alizer finds all languages that are part of the folder to detect a possible language which doesn't use a config file (e.g python)

This patch changes it a bit. If a configuration file is found only the languages associated to it are analyzed. So there are 3 different cases that may happen:

1) A configuration file is found and this is associated to only 1 language (like `go.mod` for Go, `pom.xml` and `build.gradle` for Java, `package.json` for Nodejs ....) and it makes an analysis focussing on that particular language
Example of the behavior
a pom.xml is found in folder -> so here lives a java component -> I already know the language so i don't need to make a deep analysis and i only look for frameworks/tools used -> return component {path, list of languages with only one language {JAVA}}

2) A configuration file is found and it is associated to multiple languages (like `.proj` for C#, F# and VB.NET). A deep analysis as it always happen now it's made. A component is returned having a list of all languages detected and ordered so that in first position there is C# or F# or VB.NET

3) No config file is found and a deep analysis is made to check if some language with no config file is found => PYTHON

So if we are in 2 or 3 case nothing changes from what we have now. Different is if we are in the first case. Let's say you try to analyze a huge JAVA project with thousands of file and a pom.xml is detected in root Alizer just checks it for framework/tools detection and it finishes. No need to search for other langs. WDYT?


