### PR TITLE
chore: remove GCC Machine Description from programming langs used for detection (#87)

### DIFF
--- a/go/pkg/schema/languages.go
+++ b/go/pkg/schema/languages.go
@@ -31,6 +31,7 @@ type LanguageCustomization struct {
 	Component          bool     `yaml:"component"`
 	ExcludeFolders     []string `yaml:"exclude_folders,omitempty"`
 	Aliases            []string `yaml:"aliases"`
+	Disabled           bool     `default:"false" yaml:"disable_detection"`
 }
 
 type LanguagesCustomizations map[string]LanguageCustomization

--- a/go/pkg/utils/langfiles/languages_file_handler.go
+++ b/go/pkg/utils/langfiles/languages_file_handler.go
@@ -27,6 +27,7 @@ type LanguageItem struct {
 	ConfigurationFiles []string
 	ExcludeFolders     []string
 	Component          bool
+	disabled           bool
 }
 
 type LanguageFile struct {
@@ -62,12 +63,14 @@ func create() *LanguageFile {
 			Group:   properties.Group,
 		}
 		customizeLanguage(&languageItem)
-		languages[name] = languageItem
-		extensions := properties.Extensions
-		for _, ext := range extensions {
-			languagesByExtension := extensionsXLanguage[ext]
-			languagesByExtension = append(languagesByExtension, languageItem)
-			extensionsXLanguage[ext] = languagesByExtension
+		if !languageItem.disabled {
+			languages[name] = languageItem
+			extensions := properties.Extensions
+			for _, ext := range extensions {
+				languagesByExtension := extensionsXLanguage[ext]
+				languagesByExtension = append(languagesByExtension, languageItem)
+				extensionsXLanguage[ext] = languagesByExtension
+			}
 		}
 	}
 
@@ -84,6 +87,7 @@ func customizeLanguage(languageItem *LanguageItem) {
 		(*languageItem).ExcludeFolders = customization.ExcludeFolders
 		(*languageItem).Component = customization.Component
 		(*languageItem).Aliases = appendSlice((*languageItem).Aliases, customization.Aliases)
+		(*languageItem).disabled = customization.Disabled
 	}
 }
 

--- a/go/pkg/utils/langfiles/resources/languages-customization.yml
+++ b/go/pkg/utils/langfiles/resources/languages-customization.yml
@@ -12,6 +12,8 @@ F#:
     - ".*\\.\\w+proj"
     - "appsettings.json"
   component: true
+GCC Machine Description:
+  disable_detection: true
 Go:
   configuration_files:
     - "go.mod"

--- a/resources/languages-customization.yml
+++ b/resources/languages-customization.yml
@@ -12,6 +12,8 @@ F#:
     - ".*\\.\\w+proj"
     - "appsettings.json"
   component: true
+GCC Machine Description:
+  disable_detection: true
 Go:
   configuration_files:
     - "go.mod"


### PR DESCRIPTION
it resolves #87 

This is something i was already thinking before and it was raised again by https://github.com/redhat-developer/alizer/issues/84 
Why `GCC Machine Description` files (`.md`) should be treated as a programming language? I didn't find any valid reason so far and even if we change our mind in future we can just revert the disable flag from our customization file.