### PR TITLE
feat: update component/devfile detection in JAVA (#88)

### DIFF
--- a/java/alizer-api/src/main/java/com/redhat/devtools/alizer/api/ComponentRecognizer.java
+++ b/java/alizer-api/src/main/java/com/redhat/devtools/alizer/api/ComponentRecognizer.java
@@ -14,5 +14,6 @@ import java.io.IOException;
 import java.util.List;
 
 public interface ComponentRecognizer {
+    List<Component> analyzeRoot(String path) throws IOException;
     List<Component> analyze(String path) throws IOException;
 }

--- a/java/alizer-api/src/main/java/com/redhat/devtools/alizer/api/ComponentRecognizerImpl.java
+++ b/java/alizer-api/src/main/java/com/redhat/devtools/alizer/api/ComponentRecognizerImpl.java
@@ -34,6 +34,11 @@ public class ComponentRecognizerImpl extends Recognizer implements ComponentReco
         super(builder);
     }
 
+    public List<Component> analyzeRoot(String path) throws IOException {
+        List<File> files = getFilesInDirectory(Paths.get(path));
+        return detectComponents(files);
+    }
+
     public List<Component> analyze(String path) throws IOException {
         List<File> files = getFiles(Paths.get(path));
         List<Component> components = detectComponents(files);
@@ -165,8 +170,7 @@ public class ComponentRecognizerImpl extends Recognizer implements ComponentReco
             return false;
         }
         Language mainLanguage = languages.get(0);
-        return mainLanguage.canBeComponent() &&
-                !mainLanguage.getFrameworks().isEmpty();
+        return mainLanguage.canBeComponent();
     }
 
     /**

--- a/java/alizer-api/src/main/java/com/redhat/devtools/alizer/api/ComponentRecognizerImpl.java
+++ b/java/alizer-api/src/main/java/com/redhat/devtools/alizer/api/ComponentRecognizerImpl.java
@@ -34,11 +34,23 @@ public class ComponentRecognizerImpl extends Recognizer implements ComponentReco
         super(builder);
     }
 
+    /**
+     * Analyze only files existing in path. It doesn't walk through all subfolders
+     * @param path path (root) where to make the analysis
+     * @return list of components found
+     * @throws IOException if an error occurred
+     */
     public List<Component> analyzeRoot(String path) throws IOException {
         List<File> files = getFilesInDirectory(Paths.get(path));
         return detectComponents(files);
     }
 
+    /**
+     * Analyze all files within the project to detect all components. It walks from the root through all subfolders.
+     * @param path path (root) where to start the search
+     * @return list of components found ordered. First component is the one in root.
+     * @throws IOException if an error occurred
+     */
     public List<Component> analyze(String path) throws IOException {
         List<File> files = getFiles(Paths.get(path));
         List<Component> components = detectComponents(files);
@@ -47,6 +59,15 @@ public class ComponentRecognizerImpl extends Recognizer implements ComponentReco
         // we then rely on the language recognizer
         List<Path> directoriesPathsWithoutConfigFile = getDirectoriesPathsWithoutConfigFile(Paths.get(path), components);
         components.addAll(getComponentsWithoutConfigFile(directoriesPathsWithoutConfigFile));
+
+        components.sort((o1, o2) -> {
+            if (o1.getPath().toString().equals(path)) {
+                return -1;
+            } else if (o2.getPath().toString().equals(path)) {
+                return 1;
+            }
+            return 0;
+        });
         return components;
     }
 

--- a/java/alizer-api/src/main/java/com/redhat/devtools/alizer/api/DevFileRecognizerImpl.java
+++ b/java/alizer-api/src/main/java/com/redhat/devtools/alizer/api/DevFileRecognizerImpl.java
@@ -15,9 +15,14 @@ public class DevFileRecognizerImpl extends Recognizer implements DevFileRecogniz
 
     public <T extends DevfileType> T selectDevFileFromTypes(String srcPath, List<T> devfileTypes) throws IOException {
         ComponentRecognizer componentRecognizer = builder.createComponentRecognizer();
-        List<Component> components = componentRecognizer.analyze(srcPath);
-        if (!components.isEmpty()) {
-            return selectDevFileFromTypes(components.get(0).getLanguages(), devfileTypes);
+        List<Component> componentsInRoot = componentRecognizer.analyzeRoot(srcPath);
+        if (!componentsInRoot.isEmpty()) {
+            return selectDevFileFromTypes(componentsInRoot.get(0).getLanguages(), devfileTypes);
+        }
+
+        List<Component> componentsWithinFullProject = componentRecognizer.analyze(srcPath);
+        if (!componentsWithinFullProject.isEmpty()) {
+            return selectDevFileFromTypes(componentsWithinFullProject.get(0).getLanguages(), devfileTypes);
         }
 
         LanguageRecognizer languageRecognizer = builder.createLanguageRecognizer();

--- a/java/alizer-api/src/main/java/com/redhat/devtools/alizer/api/DevFileRecognizerImpl.java
+++ b/java/alizer-api/src/main/java/com/redhat/devtools/alizer/api/DevFileRecognizerImpl.java
@@ -13,6 +13,14 @@ public class DevFileRecognizerImpl extends Recognizer implements DevFileRecogniz
         this.builder = builder;
     }
 
+    /**
+     * It tries to detect a component in the root and return a devfile for it. If there is no component in root,
+     * it start looking for some components within the sub-folders. If there are none, it uses the outcome of analyze.
+     * @param srcPath path (root) where to start the search
+     * @param devfileTypes list of all devfileTypes to pick a devfile from
+     * @return the devfile that matches the project the most
+     * @throws IOException if an error occurred
+     */
     public <T extends DevfileType> T selectDevFileFromTypes(String srcPath, List<T> devfileTypes) throws IOException {
         ComponentRecognizer componentRecognizer = builder.createComponentRecognizer();
         List<Component> componentsInRoot = componentRecognizer.analyzeRoot(srcPath);

--- a/java/alizer-api/src/main/java/com/redhat/devtools/alizer/api/Recognizer.java
+++ b/java/alizer-api/src/main/java/com/redhat/devtools/alizer/api/Recognizer.java
@@ -26,7 +26,7 @@ public class Recognizer {
         return Files.walk(rootDirectory, Integer.MAX_VALUE).filter(Files::isRegularFile).map(Path::toFile).collect(Collectors.toList());
     }
 
-    protected List<File> getFilesInDirectory(Path dir) throws IOException {
+    protected List<File> getFilesInDirectory(Path dir) {
         File[] files = dir.toFile().listFiles();
         return files != null
                 ? new ArrayList<>(Arrays.asList(files))

--- a/java/alizer-api/src/main/java/com/redhat/devtools/alizer/api/Recognizer.java
+++ b/java/alizer-api/src/main/java/com/redhat/devtools/alizer/api/Recognizer.java
@@ -14,6 +14,8 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -22,5 +24,12 @@ public class Recognizer {
 
     protected List<File> getFiles(Path rootDirectory) throws IOException {
         return Files.walk(rootDirectory, Integer.MAX_VALUE).filter(Files::isRegularFile).map(Path::toFile).collect(Collectors.toList());
+    }
+
+    protected List<File> getFilesInDirectory(Path dir) throws IOException {
+        File[] files = dir.toFile().listFiles();
+        return files != null
+                ? new ArrayList<>(Arrays.asList(files))
+                : new ArrayList<>();
     }
 }

--- a/java/alizer-api/src/test/java/com/redhat/devtools/alizer/api/ComponentRecognizerTest.java
+++ b/java/alizer-api/src/test/java/com/redhat/devtools/alizer/api/ComponentRecognizerTest.java
@@ -31,7 +31,7 @@ public class ComponentRecognizerTest extends AbstractRecognizerTest {
     @Test
     public void testSelfComponent() throws IOException {
         List<Component> components = recognizer.analyze(".");
-        assertEquals(0, components.size());
+        assertEquals(1, components.size());
     }
 
     @Test


### PR DESCRIPTION
it resolves #88 

This patch update how the detection works in JAVA to make it be the same as in Go.

The component detection works without framework constraint and the result is ordered to have the component found in root in first position.
The devfile detection is now based on component detection. A devfile is picked based on component in root, if nothing is there it uses a component in the project or the generic analyze action.

I added some comment to keep track of the behavior.