### PR TITLE
fix: prevent skipping current folder if only a single file needs to be ignored (#99)

### DIFF
--- a/go/pkg/apis/recognizer/language_recognizer.go
+++ b/go/pkg/apis/recognizer/language_recognizer.go
@@ -116,7 +116,11 @@ func GetFilePathsFromRoot(root string) ([]string, error) {
 	errWalk := filepath.Walk(root,
 		func(path string, info os.FileInfo, err error) error {
 			if errorIgnoreFile == nil && ignoreFile.MatchesPath(path) {
-				return filepath.SkipDir
+				if info.IsDir() {
+					return filepath.SkipDir
+				} else {
+					return nil
+				}
 			}
 			if !info.IsDir() && isFileInRoot(root, path) {
 				files = append([]string{path}, files...)


### PR DESCRIPTION
This fixes #99 

The problem was that if a single file matched a rule in gitignore, the whole folder was skipped. So if the file was in the root, no component were detected as only the files discovered until that moment would be used.

E.g I have this treeview
```
root 
 | -  .classpath (file)
 | -  .settings  (file)
 | -  src/  (folder)
 | -  test/ (folder)
```
The gitignore is like
```
.classpath
....
```

When Alizer walks on the `.classpath` file, it matches the rule in gitignore and all folder is skipped. 
Code in path lib which caused the misbehaviour
```
for _, name := range names {
		filename := Join(path, name)
		fileInfo, err := lstat(filename)
		err = walk(filename, fileInfo, walkFn) -> here i returned a skipDir even if it was a file
		if err != nil {
			if !fileInfo.IsDir() || err != SkipDir { --> it failed here
				return err
			}
		}		
	}
```

With this patch it skips items in the right way. Returns nil if it's a file or skipDir if it's a directory.
