### PR TITLE
Add .NET alias

### DIFF
--- a/go/pkg/utils/langfiles/resources/languages-customization.yml
+++ b/go/pkg/utils/langfiles/resources/languages-customization.yml
@@ -1,6 +1,7 @@
 C#:
   aliases:
     - "dotnet"
+    - ".NET"
   configuration_files:
     - ".*\\.\\w+proj"
     - "appsettings.json"
@@ -8,6 +9,7 @@ C#:
 F#:
   aliases:
     - "dotnet"
+    - ".NET"
   configuration_files:
     - ".*\\.\\w+proj"
     - "appsettings.json"
@@ -45,6 +47,7 @@ TypeScript:
 Visual Basic .NET:
   aliases:
     - "dotnet"
+    - ".NET"
   configuration_files:
     - ".*\\.\\w+proj"
     - "appsettings.json"

--- a/resources/languages-customization.yml
+++ b/resources/languages-customization.yml
@@ -1,6 +1,7 @@
 C#:
   aliases:
     - "dotnet"
+    - ".NET"
   configuration_files:
     - ".*\\.\\w+proj"
     - "appsettings.json"
@@ -8,6 +9,7 @@ C#:
 F#:
   aliases:
     - "dotnet"
+    - ".NET"
   configuration_files:
     - ".*\\.\\w+proj"
     - "appsettings.json"
@@ -45,6 +47,7 @@ TypeScript:
 Visual Basic .NET:
   aliases:
     - "dotnet"
+    - ".NET"
   configuration_files:
     - ".*\\.\\w+proj"
     - "appsettings.json"


### PR DESCRIPTION
Adds ".NET" alias to all places that already list "donet" as an alias



https://github.com/devfile/registry/pull/134 [updated Devfiles](https://github.com/devfile/registry/pull/134/files#diff-01e78547ca4478cb2cd863da31ce6bf19a71387b5a27f16ce270d7c48f725581R7), and they now have `language: .NET` because of this, Alizer is no longer able to match .NET project to correct Devfiles. 

This should fix it. 




