### PR TITLE
feat: add Node.JS as tool for JS/TS because of new devfile tag

### DIFF
--- a/go/pkg/apis/enricher/javascript_enricher.go
+++ b/go/pkg/apis/enricher/javascript_enricher.go
@@ -41,7 +41,7 @@ func (j JavaScriptEnricher) DoEnrichLanguage(language *model.Language, files *[]
 	packageJson := utils.GetFile(files, "package.json")
 
 	if packageJson != "" {
-		language.Tools = []string{"NodeJs"}
+		language.Tools = []string{"NodeJs", "Node.js"}
 		detectJavaScriptFrameworks(language, packageJson)
 	}
 }


### PR DESCRIPTION
Just discovered there are some devfiles that use tag `Node.JS` (eg https://registry.devfile.io/viewer/devfiles/Community+nodejs-angular)  and others `NodeJS` (e.g https://registry.devfile.io/viewer/devfiles/Community+nodejs-basic).