### PR TITLE
feat: return multiple devfiles when having multiple components

### DIFF
--- a/go/pkg/apis/enricher/javascript_enricher.go
+++ b/go/pkg/apis/enricher/javascript_enricher.go
@@ -45,7 +45,7 @@ func (j JavaScriptEnricher) DoEnrichLanguage(language *model.Language, files *[]
 	if packageJson != "" {
 		language.Tools = []string{"NodeJs", "Node.js"}
 		var targetLanguage string
-		if utils.IsTagInPackageJsonFile(packageJson, "typescript") {
+		if utils.IsTagInPackageJsonFile(packageJson, "typescript") || utils.IsTagInPackageJsonFile(packageJson, "tslib") {
 			targetLanguage = "TypeScript"
 		} else {
 			targetLanguage = "JavaScript"

--- a/go/pkg/apis/model/model.go
+++ b/go/pkg/apis/model/model.go
@@ -67,3 +67,8 @@ type PortMatchSubRule struct {
 	Regex    *regexp.Regexp
 	SubRegex *regexp.Regexp
 }
+
+type DevFileScore struct {
+	DevFileIndex int
+	Score        int
+}

--- a/go/pkg/apis/recognizer/component_recognizer.go
+++ b/go/pkg/apis/recognizer/component_recognizer.go
@@ -244,22 +244,6 @@ func appendIfMissing(components []model.Component, component model.Component) []
 	return append(components, component)
 }
 
-func hasHigherPriorityThanExisting(existing model.Component, component model.Component) bool {
-	return getComponentPriorityScore(component) > getComponentPriorityScore(existing)
-}
-
-func getComponentPriorityScore(component model.Component) int {
-	score := 1
-	mainLanguage := component.Languages[0]
-	if len(mainLanguage.Frameworks) > 0 {
-		score += utils.FRAMEWORK_WEIGHT
-	}
-	if len(mainLanguage.Tools) > 0 {
-		score += utils.TOOL_WEIGHT
-	}
-	return score
-}
-
 func getLanguagesByConfigurationFile(configurationPerLanguage map[string][]string, file string) ([]string, error) {
 	for regex, languages := range configurationPerLanguage {
 		if match, _ := regexp.MatchString(regex, file); match {

--- a/go/pkg/apis/recognizer/component_recognizer.go
+++ b/go/pkg/apis/recognizer/component_recognizer.go
@@ -244,6 +244,22 @@ func appendIfMissing(components []model.Component, component model.Component) []
 	return append(components, component)
 }
 
+func hasHigherPriorityThanExisting(existing model.Component, component model.Component) bool {
+	return getComponentPriorityScore(component) > getComponentPriorityScore(existing)
+}
+
+func getComponentPriorityScore(component model.Component) int {
+	score := 1
+	mainLanguage := component.Languages[0]
+	if len(mainLanguage.Frameworks) > 0 {
+		score += utils.FRAMEWORK_WEIGHT
+	}
+	if len(mainLanguage.Tools) > 0 {
+		score += utils.TOOL_WEIGHT
+	}
+	return score
+}
+
 func getLanguagesByConfigurationFile(configurationPerLanguage map[string][]string, file string) ([]string, error) {
 	for regex, languages := range configurationPerLanguage {
 		if match, _ := regexp.MatchString(regex, file); match {

--- a/go/pkg/apis/recognizer/devfile_recognizer.go
+++ b/go/pkg/apis/recognizer/devfile_recognizer.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	"github.com/redhat-developer/alizer/go/pkg/apis/model"
+	"github.com/redhat-developer/alizer/go/pkg/utils"
 )
 
 func SelectDevFileFromTypes(path string, devFileTypes []model.DevFileType) (int, error) {
@@ -139,21 +140,20 @@ func adaptUrl(url string) string {
 func selectDevFileByLanguage(language model.Language, devFileTypes []model.DevFileType) (int, error) {
 	scoreTarget := 0
 	devfileTarget := -1
-	FRAMEWORK_WEIGHT := 10
-	TOOL_WEIGHT := 5
+
 	for index, devFile := range devFileTypes {
 		score := 0
 		if strings.EqualFold(devFile.Language, language.Name) || matches(language.Aliases, devFile.Language) {
 			score++
 			if matches(language.Frameworks, devFile.ProjectType) {
-				score += FRAMEWORK_WEIGHT
+				score += utils.FRAMEWORK_WEIGHT
 			}
 			for _, tag := range devFile.Tags {
 				if matches(language.Frameworks, tag) {
-					score += FRAMEWORK_WEIGHT
+					score += utils.FRAMEWORK_WEIGHT
 				}
 				if matches(language.Tools, tag) {
-					score += TOOL_WEIGHT
+					score += utils.TOOL_WEIGHT
 				}
 			}
 		}

--- a/go/pkg/apis/recognizer/devfile_recognizer.go
+++ b/go/pkg/apis/recognizer/devfile_recognizer.go
@@ -24,25 +24,7 @@ import (
 )
 
 func SelectDevFilesFromTypes(path string, devFileTypes []model.DevFileType, ctx *context.Context) ([]int, error) {
-	devFilesIndexes := []int{}
-	components, _ := DetectComponentsInRoot(path)
-	for _, component := range components {
-		devFiles, err := selectDevFilesByLanguage(component.Languages[0], devFileTypes)
-		if err == nil {
-			devFilesIndexes = append(devFilesIndexes, devFiles...)
-		}
-	}
-	if len(devFilesIndexes) > 0 {
-		return devFilesIndexes, nil
-	}
-
-	components, _ = DetectComponents(path)
-	for _, component := range components {
-		devFiles, err := selectDevFilesByLanguage(component.Languages[0], devFileTypes)
-		if err == nil {
-			devFilesIndexes = append(devFilesIndexes, devFiles...)
-		}
-	}
+	devFilesIndexes := selectDevFilesFromComponentsDetectedInPath(path, devFileTypes)
 	if len(devFilesIndexes) > 0 {
 		return devFilesIndexes, nil
 	}
@@ -56,6 +38,28 @@ func SelectDevFilesFromTypes(path string, devFileTypes []model.DevFileType, ctx 
 		return []int{}, errors.New("No valid devfile found for project in " + path)
 	}
 	return []int{devfile}, nil
+}
+
+func selectDevFilesFromComponentsDetectedInPath(path string, devFileTypes []model.DevFileType) []int {
+	components, _ := DetectComponentsInRoot(path)
+	devFilesIndexes := selectDevFilesFromComponents(components, devFileTypes)
+	if len(devFilesIndexes) > 0 {
+		return devFilesIndexes
+	}
+
+	components, _ = DetectComponents(path)
+	return selectDevFilesFromComponents(components, devFileTypes)
+}
+
+func selectDevFilesFromComponents(components []model.Component, devFileTypes []model.DevFileType) []int {
+	devFilesIndexes := []int{}
+	for _, component := range components {
+		devFiles, err := selectDevFilesByLanguage(component.Languages[0], devFileTypes)
+		if err == nil {
+			devFilesIndexes = append(devFilesIndexes, devFiles...)
+		}
+	}
+	return devFilesIndexes
 }
 
 func SelectDevFileFromTypes(path string, devFileTypes []model.DevFileType) (int, error) {

--- a/go/pkg/cli/devfile/devfile.go
+++ b/go/pkg/cli/devfile/devfile.go
@@ -28,5 +28,5 @@ func doSelectDevfile(cmd *cobra.Command, args []string) {
 	if registry == "" {
 		registry = "https://registry.devfile.io/index"
 	}
-	utils.PrintPrettifyOutput(recognizer.SelectDevFileFromRegistry(args[0], registry))
+	utils.PrintPrettifyOutput(recognizer.SelectDevFilesFromRegistry(args[0], registry))
 }

--- a/go/pkg/utils/detector.go
+++ b/go/pkg/utils/detector.go
@@ -131,11 +131,9 @@ func IsTagInPackageJsonFile(file string, tag string) bool {
 }
 
 func isTagInDependencies(deps map[string]string, tag string) bool {
-	if deps != nil {
-		for dependency := range deps {
-			if strings.Contains(dependency, tag) {
-				return true
-			}
+	for dependency := range deps {
+		if strings.Contains(dependency, tag) {
+			return true
 		}
 	}
 	return false

--- a/go/pkg/utils/detector.go
+++ b/go/pkg/utils/detector.go
@@ -31,7 +31,6 @@ import (
 
 const FROM_PORT = 0
 const TO_PORT = 65535
-const PROJECT_TYPE_WEIGHT = 15
 const FRAMEWORK_WEIGHT = 10
 const TOOL_WEIGHT = 5
 

--- a/go/pkg/utils/detector.go
+++ b/go/pkg/utils/detector.go
@@ -31,6 +31,8 @@ import (
 
 const FROM_PORT = 0
 const TO_PORT = 65535
+const FRAMEWORK_WEIGHT = 10
+const TOOL_WEIGHT = 5
 
 func GetFilesByRegex(filePaths *[]string, regexFile string) []string {
 	matchedPaths := []string{}

--- a/go/pkg/utils/detector.go
+++ b/go/pkg/utils/detector.go
@@ -31,6 +31,7 @@ import (
 
 const FROM_PORT = 0
 const TO_PORT = 65535
+const PROJECT_TYPE_WEIGHT = 15
 const FRAMEWORK_WEIGHT = 10
 const TOOL_WEIGHT = 5
 

--- a/go/pkg/utils/langfiles/resources/languages-customization.yml
+++ b/go/pkg/utils/langfiles/resources/languages-customization.yml
@@ -19,7 +19,6 @@ GCC Machine Description:
 Go:
   configuration_files:
     - "go.mod"
-    - "go.sum"
   component: true
 Java:
   configuration_files:
@@ -32,7 +31,7 @@ JavaScript:
   exclude_folders:
     - "node_modules"
   configuration_files:
-    - "package.json"
+    - "[^-]package.json"
   component: true
 Python:
   component: true
@@ -46,7 +45,7 @@ TypeScript:
   exclude_folders:
     - "node_modules"
   configuration_files:
-    - "package.json"
+    - "[^-]package.json"
   component: true
 Visual Basic .NET:
   aliases:

--- a/go/pkg/utils/langfiles/resources/languages-customization.yml
+++ b/go/pkg/utils/langfiles/resources/languages-customization.yml
@@ -27,6 +27,8 @@ Java:
     - "build.gradle"
   component: true
 JavaScript:
+  aliases:
+    - "TypeScript"
   exclude_folders:
     - "node_modules"
   configuration_files:
@@ -39,6 +41,8 @@ Rust:
     - "Cargo.toml"
   component: true
 TypeScript:
+  aliases:
+    - "JavaScript"
   exclude_folders:
     - "node_modules"
   configuration_files:

--- a/go/test/apis/component_recognizer_test.go
+++ b/go/test/apis/component_recognizer_test.go
@@ -109,7 +109,7 @@ func TestComponentDetectionWithGitIgnoreRule(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	files, err = utils.GetCachedFilePathsFromRoot(testingProjectPath, &ctx)
+	files, err = utils.GetFilePathsFromRoot(testingProjectPath)
 	if err != nil {
 		t.Error(err)
 	}

--- a/go/test/apis/devfile_recognizer_test.go
+++ b/go/test/apis/devfile_recognizer_test.go
@@ -11,6 +11,7 @@ package recognizer
  * Red Hat, Inc.
  ******************************************************************************/
 import (
+	"context"
 	"testing"
 
 	"github.com/redhat-developer/alizer/go/pkg/apis/model"
@@ -18,19 +19,19 @@ import (
 )
 
 func TestDetectQuarkusDevfile(t *testing.T) {
-	detectDevFile(t, "quarkus", "java-quarkus")
+	detectDevFile(t, "quarkus", []string{"java-quarkus"})
 }
 
 func TestDetectMicronautDevfile(t *testing.T) {
-	detectDevFile(t, "micronaut", "java-maven")
+	detectDevFile(t, "micronaut", []string{"java-maven"})
 }
 
 func TestDetectNodeJSDevfile(t *testing.T) {
-	detectDevFile(t, "nodejs-ex", "nodejs")
+	detectDevFile(t, "nodejs-ex", []string{"nodejs"})
 }
 
 func TestDetectDjangoDevfile(t *testing.T) {
-	detectDevFile(t, "django", "python-django")
+	detectDevFile(t, "django", []string{"python-django"})
 }
 
 func TestDetectDjangoDevfileUsingLanguages(t *testing.T) {
@@ -58,50 +59,51 @@ func TestDetectDjangoDevfileUsingLanguages(t *testing.T) {
 			CanBeComponent: false,
 		},
 	}
-	detectDevFileUsingLanguages(t, "", languages, "python-django")
+	detectDevFileUsingLanguages(t, "", languages, []string{"python-django"})
 }
 
 func TestDetectQuarkusDevfileUsingLanguages(t *testing.T) {
-	detectDevFileUsingLanguages(t, "quarkus", []model.Language{}, "java-quarkus")
+	detectDevFileUsingLanguages(t, "quarkus", []model.Language{}, []string{"java-quarkus"})
 }
 
 func TestDetectMicronautDevfileUsingLanguages(t *testing.T) {
-	detectDevFileUsingLanguages(t, "micronaut", []model.Language{}, "java-maven")
+	detectDevFileUsingLanguages(t, "micronaut", []model.Language{}, []string{"java-maven"})
 }
 
 func TestDetectNodeJSDevfileUsingLanguages(t *testing.T) {
-	detectDevFileUsingLanguages(t, "nodejs-ex", []model.Language{}, "nodejs")
+	detectDevFileUsingLanguages(t, "nodejs-ex", []model.Language{}, []string{"nodejs"})
 }
 
 func TestDetectGoDevfile(t *testing.T) {
-	detectDevFile(t, "golang-gin-app", "go")
+	detectDevFile(t, "golang-gin-app", []string{"go"})
 }
 
 func TestDetectAngularDevfile(t *testing.T) {
-	detectDevFile(t, "angularjs", "Angular")
+	detectDevFile(t, "angularjs", []string{"Angular"})
 }
 
 func TestDetectNextJsDevfile(t *testing.T) {
-	detectDevFile(t, "nextjs-app", "Next.js")
+	detectDevFile(t, "nextjs-app", []string{"Next.js"})
 }
 
 func TestDetectNuxtJsDevfile(t *testing.T) {
-	detectDevFile(t, "nuxt-app", "nodejs-nuxtjs")
+	detectDevFile(t, "nuxt-app", []string{"nodejs-nuxtjs", "nodejs-vue"})
 }
 
 func TestDetectVueDevfile(t *testing.T) {
-	detectDevFile(t, "vue-app", "nodejs-vue")
+	detectDevFile(t, "vue-app", []string{"nodejs-vue"})
 }
 
-func detectDevFile(t *testing.T, projectName string, devFileName string) {
-	detectDevFileFunc := func(devFileTypes []model.DevFileType) (int, error) {
+func detectDevFile(t *testing.T, projectName string, devFilesName []string) {
+	detectDevFilesFunc := func(devFileTypes []model.DevFileType) ([]int, error) {
+		ctx := context.Background()
 		testingProjectPath := GetTestProjectPath(projectName)
-		return recognizer.SelectDevFileFromTypes(testingProjectPath, devFileTypes)
+		return recognizer.SelectDevFilesFromTypes(testingProjectPath, devFileTypes, &ctx)
 	}
-	detectDevFileInner(t, devFileName, detectDevFileFunc)
+	detectDevFileInner(t, devFilesName, detectDevFilesFunc)
 }
 
-func detectDevFileUsingLanguages(t *testing.T, projectName string, languages []model.Language, devFileName string) {
+func detectDevFileUsingLanguages(t *testing.T, projectName string, languages []model.Language, devFileName []string) {
 	if projectName != "" {
 		testingProjectPath := GetTestProjectPath(projectName)
 		var err error
@@ -110,21 +112,31 @@ func detectDevFileUsingLanguages(t *testing.T, projectName string, languages []m
 			t.Error(err)
 		}
 	}
-	detectDevFileFunc := func(devFileTypes []model.DevFileType) (int, error) {
-		return recognizer.SelectDevFileUsingLanguagesFromTypes(languages, devFileTypes)
+	detectDevFileFunc := func(devFileTypes []model.DevFileType) ([]int, error) {
+		return recognizer.SelectDevFilesUsingLanguagesFromTypes(languages, devFileTypes)
 	}
 	detectDevFileInner(t, devFileName, detectDevFileFunc)
 }
 
-func detectDevFileInner(t *testing.T, devFileName string, detectFuncInner func([]model.DevFileType) (int, error)) {
+func detectDevFileInner(t *testing.T, expectedDevFilesName []string, detectFuncInner func([]model.DevFileType) ([]int, error)) {
 	devFileTypes := getDevFileTypes()
-	devFileTarget, err := detectFuncInner(devFileTypes)
+	foundDevFilesIndexes, err := detectFuncInner(devFileTypes)
 	if err != nil {
 		t.Error(err)
 	}
 
-	if devFileTypes[devFileTarget].Name != devFileName {
-		t.Error("Expected value " + devFileName + " but it was" + devFileTypes[devFileTarget].Name)
+	found := false
+	for _, expectedDevFile := range expectedDevFilesName {
+		found = false
+		for _, foundDevFileIndex := range foundDevFilesIndexes {
+			if devFileTypes[foundDevFileIndex].Name == expectedDevFile {
+				found = true
+			}
+		}
+		if !found {
+			t.Error("Expected value " + expectedDevFile + " but it was not found")
+			return
+		}
 	}
 }
 

--- a/go/test/git_test.json
+++ b/go/test/git_test.json
@@ -23,17 +23,7 @@
                         "tools": [
                             "1.14"
                         ]
-                    },
-                    {
-                        "name": "Modula-2",
-                        "frameworks": [],
-                        "tools": []
-                    },
-                    {
-                        "name": "AMPL",
-                        "frameworks": [],
-                        "tools": []
-                    }        
+                    }      
                 ]
             }
         ]
@@ -71,17 +61,7 @@
                         "tools": [
                             "1.18"
                         ]
-                    },
-                    {
-                        "name": "Smarty",
-                        "frameworks": [],
-                        "tools": []
-                    },
-                    {
-                        "name": "Shell",
-                        "frameworks": [],
-                        "tools": []
-                    }  
+                    }
                 ]
             }
         ]
@@ -100,11 +80,6 @@
                         "tools": [
                             "1.19"
                         ]
-                    },
-                    {
-                        "name": "Assembly",
-                        "frameworks": [],
-                        "tools": []
                     }
                 ],
                 "ports": [
@@ -173,7 +148,12 @@
                         "tools": [
                             "Maven"
                         ]
-                    },
+                    }
+                ]
+            },
+            {
+                "name": "jhipster-sample-application",
+                "languages": [
                     {
                         "name": "TypeScript",
                         "frameworks": [
@@ -238,7 +218,7 @@
                             "Spring"
                         ],
                         "tools": [
-                            "Gradle"
+                            "Maven"
                         ]
                     }
                 ]
@@ -274,19 +254,12 @@
                     {
                         "name": "TypeScript",
                         "frameworks": [
-                            "Angular"
+                            "Angular",
+                            "Express"
                         ],
                         "tools": [
-                            "NodeJs"
-                        ]
-                    },
-                    {
-                        "name": "JavaScript",
-                        "frameworks": [
-                            "Angular"
-                        ],
-                        "tools": [
-                            "NodeJs"
+                            "NodeJs",
+                            "Node.js"
                         ]
                     }
                 ]
@@ -296,15 +269,6 @@
                 "languages": [
                     {
                         "name": "TypeScript",
-                        "frameworks": [
-                            "Angular"
-                        ],
-                        "tools": [
-                            "NodeJs"
-                        ]
-                    },
-                    {
-                        "name": "JavaScript",
                         "frameworks": [
                             "Angular"
                         ],
@@ -709,7 +673,7 @@
                 "name": "opossum-angular",
                 "languages": [
                     {
-                        "name": "TypeScript",
+                        "name": "JavaScript",
                         "frameworks": [
                             "Express"
                         ],

--- a/java/alizer-api/src/main/java/com/redhat/devtools/alizer/api/ComponentRecognizerImpl.java
+++ b/java/alizer-api/src/main/java/com/redhat/devtools/alizer/api/ComponentRecognizerImpl.java
@@ -152,7 +152,7 @@ public class ComponentRecognizerImpl extends Recognizer implements ComponentReco
     }
 
     private Optional<String> getConfigurationByFile(Set<String> regexes, File file) {
-        return regexes.stream().filter(regex -> Pattern.matches(regex, file.getName())).findFirst();
+        return regexes.stream().filter(regex -> Pattern.matches(regex, file.getName()) || Pattern.matches(regex, "/" + file.getName())).findFirst();
     }
 
     private List<String> getLanguagesWithWhichConfigurationIsValid(List<String> languages, File file) {

--- a/resources/languages-customization.yml
+++ b/resources/languages-customization.yml
@@ -19,7 +19,6 @@ GCC Machine Description:
 Go:
   configuration_files:
     - "go.mod"
-    - "go.sum"
   component: true
 Java:
   configuration_files:
@@ -32,7 +31,7 @@ JavaScript:
   exclude_folders:
     - "node_modules"
   configuration_files:
-    - "package.json"
+    - "[^-]package.json"
   component: true
 Python:
   component: true
@@ -46,7 +45,7 @@ TypeScript:
   exclude_folders:
     - "node_modules"
   configuration_files:
-    - "package.json"
+    - "[^-]package.json"
   component: true
 Visual Basic .NET:
   aliases:

--- a/resources/languages-customization.yml
+++ b/resources/languages-customization.yml
@@ -27,6 +27,8 @@ Java:
     - "build.gradle"
   component: true
 JavaScript:
+  aliases:
+    - "TypeScript"
   exclude_folders:
     - "node_modules"
   configuration_files:
@@ -39,6 +41,8 @@ Rust:
     - "Cargo.toml"
   component: true
 TypeScript:
+  aliases:
+    - "JavaScript"
   exclude_folders:
     - "node_modules"
   configuration_files:


### PR DESCRIPTION
it resolves #114 https://github.com/redhat-developer/alizer/issues/117

This patch contains some improvements to solve the issue faced with the `quarkus super heroes ui` app.

- it checks devDependencies to search for the framework
- it accepts multiple components detection in same path (e.g java and typescript in the root)
- it adds a new method to retrieve a list of devfiles for the project
- JavaScript and TypeScript are considered equivalent when picking a devfile. So a ts devfile is valid for a js project and viceversa.

The ouput of the `quarkus super heroes ui` app is 

```
[
        {
                "Name": "java-maven",
                "Language": "Java",
                "ProjectType": "Maven",
                "Tags": [
                        "Java",
                        "Maven"
                ]
        },
        {
                "Name": "java-openliberty",
                "Language": "Java",
                "ProjectType": "Open Liberty",
                "Tags": [
                        "Java",
                        "Maven"
                ]
        },
        {
                "Name": "java-websphereliberty",
                "Language": "Java",
                "ProjectType": "WebSphere Liberty",
                "Tags": [
                        "Java",
                        "Maven",
                        "WebSphere Liberty"
                ]
        },
        {
                "Name": "java-wildfly-bootable-jar",
                "Language": "Java",
                "ProjectType": "WildFly",
                "Tags": [
                        "RHEL8",
                        "Java",
                        "OpenJDK",
                        "Maven",
                        "WildFly",
                        "Microprofile",
                        "WildFly Bootable"
                ]
        },
        {
                "Name": "nodejs",
                "Language": "JavaScript",
                "ProjectType": "Node.js",
                "Tags": [
                        "Node.js",
                        "Express",
                        "ubi8"
                ]
        },
        {
                "Name": "nodejs-angular",
                "Language": "TypeScript",
                "ProjectType": "Angular",
                "Tags": [
                        "Node.js",
                        "Angular"
                ]
        }
]
```
 
