### PR TITLE
fix: improve alizer performances (#118)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,7 @@ Please note that the devfile object that is returned by the method is one of the
 
 Alizer is also able to detect components. The concept of component is taken from Odo and its definition can be read on [odo.dev](https://odo.dev/docs/getting-started/basics/#component).
 
-The detection of a component is based on two rules. It is discovered if and only if:
-
-1) The main language of the component source is one of those that supports component detection (Java, Python, Javascript, Go)
-2) The source has at least one framework
+The detection of a component is based on only one rule. It is discovered if and only if the main language of the component source is one of those that supports component detection (Java, Python, Javascript, Go, ...)
 
 The result is a list of components where each component consists of:
 - *path*: root of the component 

--- a/go/README.md
+++ b/go/README.md
@@ -52,7 +52,10 @@ and it consists of two steps:
 1) Detect languages which have a configuration file such as Java (`pom.xml`, `build.gradle`)
 2) Detect languages which may not have a configuration file such as Python
 
-Alizer scans all files in the source tree to find out a configuration file. If found and the language detected is enabled (belong to the list above) a component is said to be found starting from that path. Only one component per path is possible. This step gets repeated for all configuration files present in the source tree which live into different paths.
+Alizer scans all files in the source tree to find out a configuration file. If found and the language associated to it (e.g pom.xml -> JAVA) is enabled (belong to the list above) a component is said to be found starting from that path. This step gets repeated for all configuration files present in the source tree.
+
+To speed up the detection only the language associated to the configuration file is analyzed. If a configuration file can be associated to multiple languages (e.g. `.proj` can be part of either a C# or F# or VB.NET project) then a deep analysis is made.
+
 Once the first step ends up, if there are no other free subfolders (free = folders that do not belong to any component) the second step is skipped otherwise Alizer tries to search for a component written with a language which may not have a configuration file. In that subfolder a simple Language detection is performed and the first language is taken into account for further calculations. 
 
 The result is a list of components where each component consists of:

--- a/go/pkg/apis/enricher/dotnet_enricher.go
+++ b/go/pkg/apis/enricher/dotnet_enricher.go
@@ -11,6 +11,8 @@
 package enricher
 
 import (
+	"context"
+
 	framework "github.com/redhat-developer/alizer/go/pkg/apis/enricher/framework/dotnet"
 	"github.com/redhat-developer/alizer/go/pkg/apis/model"
 	utils "github.com/redhat-developer/alizer/go/pkg/utils"
@@ -35,7 +37,7 @@ func (j DotNetEnricher) DoEnrichLanguage(language *model.Language, files *[]stri
 	}
 }
 
-func (j DotNetEnricher) DoEnrichComponent(component *model.Component, settings model.DetectionSettings) {
+func (j DotNetEnricher) DoEnrichComponent(component *model.Component, settings model.DetectionSettings, ctx *context.Context) {
 	projectName := GetDefaultProjectName(component.Path)
 	component.Name = projectName
 

--- a/go/pkg/apis/enricher/enricher.go
+++ b/go/pkg/apis/enricher/enricher.go
@@ -11,6 +11,7 @@
 package enricher
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -29,20 +30,20 @@ import (
 type Enricher interface {
 	GetSupportedLanguages() []string
 	DoEnrichLanguage(language *model.Language, files *[]string)
-	DoEnrichComponent(component *model.Component, settings model.DetectionSettings)
+	DoEnrichComponent(component *model.Component, settings model.DetectionSettings, ctx *context.Context)
 	IsConfigValidForComponentDetection(language string, configFile string) bool
 }
 
 type FrameworkDetectorWithConfigFile interface {
 	GetSupportedFrameworks() []string
 	DoFrameworkDetection(language *model.Language, config string)
-	DoPortsDetection(component *model.Component)
+	DoPortsDetection(component *model.Component, ctx *context.Context)
 }
 
 type FrameworkDetectorWithoutConfigFile interface {
 	GetSupportedFrameworks() []string
 	DoFrameworkDetection(language *model.Language, files *[]string)
-	DoPortsDetection(component *model.Component)
+	DoPortsDetection(component *model.Component, ctx *context.Context)
 }
 
 /*

--- a/go/pkg/apis/enricher/enricher.go
+++ b/go/pkg/apis/enricher/enricher.go
@@ -173,7 +173,7 @@ func GetPortsFromDockerComposeFile(componentPath string, settings model.Detectio
 }
 
 func getDockerComposeFileBytes(root string) ([]byte, error) {
-	return utils.ReadAnyApplicationFile(root, []model.ApplicationFileInfo{
+	return utils.ReadAnyApplicationFileExactMatch(root, []model.ApplicationFileInfo{
 		{
 			Dir:  "",
 			File: "docker-compose.yml",

--- a/go/pkg/apis/enricher/framework/dotnet/dotnet_detector.go
+++ b/go/pkg/apis/enricher/framework/dotnet/dotnet_detector.go
@@ -11,6 +11,7 @@
 package enricher
 
 import (
+	"context"
 	"encoding/xml"
 	"io/ioutil"
 	"os"
@@ -46,7 +47,7 @@ func (d DotNetDetector) DoFrameworkDetection(language *model.Language, configFil
 	}
 }
 
-func (d DotNetDetector) DoPortsDetection(component *model.Component) {
+func (d DotNetDetector) DoPortsDetection(component *model.Component, ctx *context.Context) {
 }
 
 func getFrameworks(configFilePath string) string {

--- a/go/pkg/apis/enricher/framework/go/beego_detector.go
+++ b/go/pkg/apis/enricher/framework/go/beego_detector.go
@@ -11,6 +11,7 @@
 package enricher
 
 import (
+	"context"
 	"regexp"
 
 	"github.com/redhat-developer/alizer/go/pkg/apis/model"
@@ -35,13 +36,13 @@ type ApplicationPropertiesFile struct {
 	File string
 }
 
-func (b BeegoDetector) DoPortsDetection(component *model.Component) {
+func (b BeegoDetector) DoPortsDetection(component *model.Component, ctx *context.Context) {
 	bytes, err := utils.ReadAnyApplicationFile(component.Path, []model.ApplicationFileInfo{
 		{
 			Dir:  "conf",
 			File: "app.conf",
 		},
-	})
+	}, ctx)
 	if err != nil {
 		return
 	}

--- a/go/pkg/apis/enricher/framework/go/echo_detector.go
+++ b/go/pkg/apis/enricher/framework/go/echo_detector.go
@@ -11,6 +11,7 @@
 package enricher
 
 import (
+	"context"
 	"os"
 	"regexp"
 
@@ -31,8 +32,8 @@ func (e EchoDetector) DoFrameworkDetection(language *model.Language, goMod *modf
 	}
 }
 
-func (e EchoDetector) DoPortsDetection(component *model.Component) {
-	files, err := utils.GetCachedFilePathsFromRoot(component.Path)
+func (e EchoDetector) DoPortsDetection(component *model.Component, ctx *context.Context) {
+	files, err := utils.GetCachedFilePathsFromRoot(component.Path, ctx)
 	if err != nil {
 		return
 	}

--- a/go/pkg/apis/enricher/framework/go/echo_detector.go
+++ b/go/pkg/apis/enricher/framework/go/echo_detector.go
@@ -32,7 +32,7 @@ func (e EchoDetector) DoFrameworkDetection(language *model.Language, goMod *modf
 }
 
 func (e EchoDetector) DoPortsDetection(component *model.Component) {
-	files, err := utils.GetFilePathsFromRoot(component.Path)
+	files, err := utils.GetCachedFilePathsFromRoot(component.Path)
 	if err != nil {
 		return
 	}

--- a/go/pkg/apis/enricher/framework/go/fasthttp_detector.go
+++ b/go/pkg/apis/enricher/framework/go/fasthttp_detector.go
@@ -11,6 +11,7 @@
 package enricher
 
 import (
+	"context"
 	"os"
 	"regexp"
 
@@ -31,8 +32,8 @@ func (f FastHttpDetector) DoFrameworkDetection(language *model.Language, goMod *
 	}
 }
 
-func (f FastHttpDetector) DoPortsDetection(component *model.Component) {
-	files, err := utils.GetCachedFilePathsFromRoot(component.Path)
+func (f FastHttpDetector) DoPortsDetection(component *model.Component, ctx *context.Context) {
+	files, err := utils.GetCachedFilePathsFromRoot(component.Path, ctx)
 	if err != nil {
 		return
 	}

--- a/go/pkg/apis/enricher/framework/go/fasthttp_detector.go
+++ b/go/pkg/apis/enricher/framework/go/fasthttp_detector.go
@@ -32,7 +32,7 @@ func (f FastHttpDetector) DoFrameworkDetection(language *model.Language, goMod *
 }
 
 func (f FastHttpDetector) DoPortsDetection(component *model.Component) {
-	files, err := utils.GetFilePathsFromRoot(component.Path)
+	files, err := utils.GetCachedFilePathsFromRoot(component.Path)
 	if err != nil {
 		return
 	}

--- a/go/pkg/apis/enricher/framework/go/gin_detector.go
+++ b/go/pkg/apis/enricher/framework/go/gin_detector.go
@@ -32,7 +32,7 @@ func (g GinDetector) DoFrameworkDetection(language *model.Language, goMod *modfi
 }
 
 func (g GinDetector) DoPortsDetection(component *model.Component) {
-	files, err := utils.GetFilePathsFromRoot(component.Path)
+	files, err := utils.GetCachedFilePathsFromRoot(component.Path)
 	if err != nil {
 		return
 	}

--- a/go/pkg/apis/enricher/framework/go/gin_detector.go
+++ b/go/pkg/apis/enricher/framework/go/gin_detector.go
@@ -11,6 +11,7 @@
 package enricher
 
 import (
+	"context"
 	"os"
 	"regexp"
 
@@ -31,8 +32,8 @@ func (g GinDetector) DoFrameworkDetection(language *model.Language, goMod *modfi
 	}
 }
 
-func (g GinDetector) DoPortsDetection(component *model.Component) {
-	files, err := utils.GetCachedFilePathsFromRoot(component.Path)
+func (g GinDetector) DoPortsDetection(component *model.Component, ctx *context.Context) {
+	files, err := utils.GetCachedFilePathsFromRoot(component.Path, ctx)
 	if err != nil {
 		return
 	}

--- a/go/pkg/apis/enricher/framework/go/gofiber_detector.go
+++ b/go/pkg/apis/enricher/framework/go/gofiber_detector.go
@@ -32,7 +32,7 @@ func (g GoFiberDetector) DoFrameworkDetection(language *model.Language, goMod *m
 }
 
 func (g GoFiberDetector) DoPortsDetection(component *model.Component) {
-	files, err := utils.GetFilePathsFromRoot(component.Path)
+	files, err := utils.GetCachedFilePathsFromRoot(component.Path)
 	if err != nil {
 		return
 	}

--- a/go/pkg/apis/enricher/framework/go/gofiber_detector.go
+++ b/go/pkg/apis/enricher/framework/go/gofiber_detector.go
@@ -11,6 +11,7 @@
 package enricher
 
 import (
+	"context"
 	"os"
 	"regexp"
 
@@ -31,8 +32,8 @@ func (g GoFiberDetector) DoFrameworkDetection(language *model.Language, goMod *m
 	}
 }
 
-func (g GoFiberDetector) DoPortsDetection(component *model.Component) {
-	files, err := utils.GetCachedFilePathsFromRoot(component.Path)
+func (g GoFiberDetector) DoPortsDetection(component *model.Component, ctx *context.Context) {
+	files, err := utils.GetCachedFilePathsFromRoot(component.Path, ctx)
 	if err != nil {
 		return
 	}

--- a/go/pkg/apis/enricher/framework/go/mux_detector.go
+++ b/go/pkg/apis/enricher/framework/go/mux_detector.go
@@ -11,6 +11,7 @@
 package enricher
 
 import (
+	"context"
 	"os"
 	"regexp"
 
@@ -31,8 +32,8 @@ func (m MuxDetector) DoFrameworkDetection(language *model.Language, goMod *modfi
 	}
 }
 
-func (m MuxDetector) DoPortsDetection(component *model.Component) {
-	files, err := utils.GetCachedFilePathsFromRoot(component.Path)
+func (m MuxDetector) DoPortsDetection(component *model.Component, ctx *context.Context) {
+	files, err := utils.GetCachedFilePathsFromRoot(component.Path, ctx)
 	if err != nil {
 		return
 	}

--- a/go/pkg/apis/enricher/framework/go/mux_detector.go
+++ b/go/pkg/apis/enricher/framework/go/mux_detector.go
@@ -32,7 +32,7 @@ func (m MuxDetector) DoFrameworkDetection(language *model.Language, goMod *modfi
 }
 
 func (m MuxDetector) DoPortsDetection(component *model.Component) {
-	files, err := utils.GetFilePathsFromRoot(component.Path)
+	files, err := utils.GetCachedFilePathsFromRoot(component.Path)
 	if err != nil {
 		return
 	}

--- a/go/pkg/apis/enricher/framework/java/micronaut_detector.go
+++ b/go/pkg/apis/enricher/framework/java/micronaut_detector.go
@@ -11,6 +11,7 @@
 package enricher
 
 import (
+	"context"
 	"os"
 
 	"github.com/redhat-developer/alizer/go/pkg/apis/model"
@@ -42,7 +43,7 @@ func (m MicronautDetector) DoFrameworkDetection(language *model.Language, config
 	}
 }
 
-func (m MicronautDetector) DoPortsDetection(component *model.Component) {
+func (m MicronautDetector) DoPortsDetection(component *model.Component, ctx *context.Context) {
 	// check if port is set on env var
 	ports := getMicronautPortsFromEnvs()
 	if len(ports) > 0 {
@@ -59,7 +60,7 @@ func (m MicronautDetector) DoPortsDetection(component *model.Component) {
 			Dir:  "src/main/resources",
 			File: "application.yaml",
 		},
-	})
+	}, ctx)
 	if err != nil {
 		return
 	}

--- a/go/pkg/apis/enricher/framework/java/openliberty_detector.go
+++ b/go/pkg/apis/enricher/framework/java/openliberty_detector.go
@@ -11,6 +11,7 @@
 package enricher
 
 import (
+	"context"
 	"encoding/xml"
 
 	"github.com/redhat-developer/alizer/go/pkg/apis/model"
@@ -38,7 +39,7 @@ func (o OpenLibertyDetector) DoFrameworkDetection(language *model.Language, conf
 	}
 }
 
-func (o OpenLibertyDetector) DoPortsDetection(component *model.Component) {
+func (o OpenLibertyDetector) DoPortsDetection(component *model.Component, ctx *context.Context) {
 	bytes, err := utils.ReadAnyApplicationFile(component.Path, []model.ApplicationFileInfo{
 		{
 			Dir:  "",
@@ -48,7 +49,7 @@ func (o OpenLibertyDetector) DoPortsDetection(component *model.Component) {
 			Dir:  "src/main/liberty/config",
 			File: "server.xml",
 		},
-	})
+	}, ctx)
 	if err != nil {
 		return
 	}

--- a/go/pkg/apis/enricher/framework/java/quarkus_detector.go
+++ b/go/pkg/apis/enricher/framework/java/quarkus_detector.go
@@ -11,6 +11,7 @@
 package enricher
 
 import (
+	"context"
 	"errors"
 	"io/ioutil"
 	"os"
@@ -47,7 +48,7 @@ func (q QuarkusDetector) DoFrameworkDetection(language *model.Language, config s
 	}
 }
 
-func (q QuarkusDetector) DoPortsDetection(component *model.Component) {
+func (q QuarkusDetector) DoPortsDetection(component *model.Component, ctx *context.Context) {
 	// check if port is set on env var
 	ports := getQuarkusPortsFromEnvs()
 	if len(ports) > 0 {
@@ -79,7 +80,7 @@ func (q QuarkusDetector) DoPortsDetection(component *model.Component) {
 			Dir:  "src/main/resources",
 			File: "application.yaml",
 		},
-	})
+	}, ctx)
 	if applicationFile == "" {
 		return
 	}

--- a/go/pkg/apis/enricher/framework/java/spring_detector.go
+++ b/go/pkg/apis/enricher/framework/java/spring_detector.go
@@ -11,6 +11,7 @@
 package enricher
 
 import (
+	"context"
 	"errors"
 	"io/ioutil"
 	"path/filepath"
@@ -41,7 +42,7 @@ func (s SpringDetector) DoFrameworkDetection(language *model.Language, config st
 	}
 }
 
-func (s SpringDetector) DoPortsDetection(component *model.Component) {
+func (s SpringDetector) DoPortsDetection(component *model.Component, ctx *context.Context) {
 	// check if port is set on env var
 	ports := getSpringPortsFromEnvs()
 	if len(ports) > 0 {
@@ -62,7 +63,7 @@ func (s SpringDetector) DoPortsDetection(component *model.Component) {
 			Dir:  "src/main/resources",
 			File: "application.yaml",
 		},
-	})
+	}, ctx)
 	if applicationFile == "" {
 		return
 	}

--- a/go/pkg/apis/enricher/framework/java/vertx_detector.go
+++ b/go/pkg/apis/enricher/framework/java/vertx_detector.go
@@ -11,6 +11,7 @@
 package enricher
 
 import (
+	"context"
 	"encoding/json"
 
 	"github.com/redhat-developer/alizer/go/pkg/apis/model"
@@ -37,13 +38,13 @@ func (v VertxDetector) DoFrameworkDetection(language *model.Language, config str
 	}
 }
 
-func (v VertxDetector) DoPortsDetection(component *model.Component) {
+func (v VertxDetector) DoPortsDetection(component *model.Component, ctx *context.Context) {
 	bytes, err := utils.ReadAnyApplicationFile(component.Path, []model.ApplicationFileInfo{
 		{
 			Dir:  "src/main/conf",
 			File: ".*.json",
 		},
-	})
+	}, ctx)
 	if err != nil {
 		return
 	}

--- a/go/pkg/apis/enricher/framework/javascript/nodejs/angular_detector.go
+++ b/go/pkg/apis/enricher/framework/javascript/nodejs/angular_detector.go
@@ -11,6 +11,7 @@
 package enricher
 
 import (
+	"context"
 	"encoding/json"
 
 	"github.com/redhat-developer/alizer/go/pkg/apis/model"
@@ -52,14 +53,14 @@ func (a AngularDetector) DoFrameworkDetection(language *model.Language, config s
 	}
 }
 
-func (a AngularDetector) DoPortsDetection(component *model.Component) {
+func (a AngularDetector) DoPortsDetection(component *model.Component, ctx *context.Context) {
 	// check if port is set on angular.json file
 	bytes, err := utils.ReadAnyApplicationFile(component.Path, []model.ApplicationFileInfo{
 		{
 			Dir:  "",
 			File: "angular.json",
 		},
-	})
+	}, ctx)
 	if err != nil {
 		return
 	}
@@ -90,7 +91,7 @@ func (a AngularDetector) DoPortsDetection(component *model.Component) {
 			Dir:  "",
 			File: "angular-cli.json",
 		},
-	})
+	}, ctx)
 	if err != nil {
 		return
 	}

--- a/go/pkg/apis/enricher/framework/javascript/nodejs/express_detector.go
+++ b/go/pkg/apis/enricher/framework/javascript/nodejs/express_detector.go
@@ -11,6 +11,7 @@
 package enricher
 
 import (
+	"context"
 	"os"
 	"regexp"
 	"strings"
@@ -31,8 +32,8 @@ func (e ExpressDetector) DoFrameworkDetection(language *model.Language, config s
 	}
 }
 
-func (e ExpressDetector) DoPortsDetection(component *model.Component) {
-	files, err := utils.GetCachedFilePathsFromRoot(component.Path)
+func (e ExpressDetector) DoPortsDetection(component *model.Component, ctx *context.Context) {
+	files, err := utils.GetCachedFilePathsFromRoot(component.Path, ctx)
 	if err != nil {
 		return
 	}

--- a/go/pkg/apis/enricher/framework/javascript/nodejs/express_detector.go
+++ b/go/pkg/apis/enricher/framework/javascript/nodejs/express_detector.go
@@ -32,7 +32,7 @@ func (e ExpressDetector) DoFrameworkDetection(language *model.Language, config s
 }
 
 func (e ExpressDetector) DoPortsDetection(component *model.Component) {
-	files, err := utils.GetFilePathsFromRoot(component.Path)
+	files, err := utils.GetCachedFilePathsFromRoot(component.Path)
 	if err != nil {
 		return
 	}

--- a/go/pkg/apis/enricher/framework/javascript/nodejs/next_detector.go
+++ b/go/pkg/apis/enricher/framework/javascript/nodejs/next_detector.go
@@ -11,6 +11,8 @@
 package enricher
 
 import (
+	"context"
+
 	"github.com/redhat-developer/alizer/go/pkg/apis/model"
 	"github.com/redhat-developer/alizer/go/pkg/utils"
 )
@@ -27,7 +29,7 @@ func (n NextDetector) DoFrameworkDetection(language *model.Language, config stri
 	}
 }
 
-func (n NextDetector) DoPortsDetection(component *model.Component) {
+func (n NextDetector) DoPortsDetection(component *model.Component, ctx *context.Context) {
 	regexes := []string{`-p (\d*)`}
 	// check if port is set in start script in package.json
 	port := getPortFromStartScript(component.Path, regexes)

--- a/go/pkg/apis/enricher/framework/javascript/nodejs/nuxt_detector.go
+++ b/go/pkg/apis/enricher/framework/javascript/nodejs/nuxt_detector.go
@@ -11,6 +11,7 @@
 package enricher
 
 import (
+	"context"
 	"regexp"
 
 	"github.com/redhat-developer/alizer/go/pkg/apis/model"
@@ -29,7 +30,7 @@ func (n NuxtDetector) DoFrameworkDetection(language *model.Language, config stri
 	}
 }
 
-func (n NuxtDetector) DoPortsDetection(component *model.Component) {
+func (n NuxtDetector) DoPortsDetection(component *model.Component, ctx *context.Context) {
 	regexes := []string{`--port=(\d*)`}
 	// check if port is set in start script in package.json
 	port := getPortFromStartScript(component.Path, regexes)
@@ -51,7 +52,7 @@ func (n NuxtDetector) DoPortsDetection(component *model.Component) {
 			Dir:  "",
 			File: "nuxt.config.js",
 		},
-	})
+	}, ctx)
 	if err != nil {
 		return
 	}

--- a/go/pkg/apis/enricher/framework/javascript/nodejs/reactjs_detector.go
+++ b/go/pkg/apis/enricher/framework/javascript/nodejs/reactjs_detector.go
@@ -11,6 +11,7 @@
 package enricher
 
 import (
+	"context"
 	"os"
 
 	"github.com/redhat-developer/alizer/go/pkg/apis/model"
@@ -29,7 +30,7 @@ func (r ReactJsDetector) DoFrameworkDetection(language *model.Language, config s
 	}
 }
 
-func (r ReactJsDetector) DoPortsDetection(component *model.Component) {
+func (r ReactJsDetector) DoPortsDetection(component *model.Component, ctx *context.Context) {
 	// check if port is set on env var
 	portValue := os.Getenv("PORT")
 	if port, err := utils.GetValidPort(portValue); err == nil {

--- a/go/pkg/apis/enricher/framework/javascript/nodejs/svelte_detector.go
+++ b/go/pkg/apis/enricher/framework/javascript/nodejs/svelte_detector.go
@@ -11,6 +11,8 @@
 package enricher
 
 import (
+	"context"
+
 	"github.com/redhat-developer/alizer/go/pkg/apis/model"
 	"github.com/redhat-developer/alizer/go/pkg/utils"
 )
@@ -27,7 +29,7 @@ func (n SvelteDetector) DoFrameworkDetection(language *model.Language, config st
 	}
 }
 
-func (n SvelteDetector) DoPortsDetection(component *model.Component) {
+func (n SvelteDetector) DoPortsDetection(component *model.Component, ctx *context.Context) {
 	// check if port is set in start script in package.json
 	port := getPortFromDevScript(component.Path, []string{`--port (\d*)`, `PORT=(\d*)`})
 	if utils.IsValidPort(port) {

--- a/go/pkg/apis/enricher/framework/javascript/nodejs/vue_detector.go
+++ b/go/pkg/apis/enricher/framework/javascript/nodejs/vue_detector.go
@@ -11,6 +11,7 @@
 package enricher
 
 import (
+	"context"
 	"regexp"
 
 	"github.com/redhat-developer/alizer/go/pkg/apis/model"
@@ -29,7 +30,7 @@ func (v VueDetector) DoFrameworkDetection(language *model.Language, config strin
 	}
 }
 
-func (v VueDetector) DoPortsDetection(component *model.Component) {
+func (v VueDetector) DoPortsDetection(component *model.Component, ctx *context.Context) {
 	regexes := []string{`--port (\d*)`, `PORT=(\d*)`}
 	// check if --port or PORT is set in start script in package.json
 	port := getPortFromStartScript(component.Path, regexes)
@@ -56,7 +57,7 @@ func (v VueDetector) DoPortsDetection(component *model.Component) {
 			Dir:  "",
 			File: "vue.config.js",
 		},
-	})
+	}, ctx)
 	if err != nil {
 		return
 	}

--- a/go/pkg/apis/enricher/framework/python/django_detector.go
+++ b/go/pkg/apis/enricher/framework/python/django_detector.go
@@ -11,6 +11,7 @@
 package enricher
 
 import (
+	"context"
 	"regexp"
 
 	"github.com/redhat-developer/alizer/go/pkg/apis/model"
@@ -45,13 +46,13 @@ type ApplicationPropertiesFile struct {
 	File string
 }
 
-func (d DjangoDetector) DoPortsDetection(component *model.Component) {
+func (d DjangoDetector) DoPortsDetection(component *model.Component, ctx *context.Context) {
 	bytes, err := utils.ReadAnyApplicationFile(component.Path, []model.ApplicationFileInfo{
 		{
 			Dir:  "",
 			File: "manage.py",
 		},
-	})
+	}, ctx)
 	if err != nil {
 		return
 	}

--- a/go/pkg/apis/enricher/go_enricher.go
+++ b/go/pkg/apis/enricher/go_enricher.go
@@ -11,6 +11,7 @@
 package enricher
 
 import (
+	"context"
 	"errors"
 	"io/ioutil"
 
@@ -25,7 +26,7 @@ type GoEnricher struct{}
 type GoFrameworkDetector interface {
 	GetSupportedFrameworks() []string
 	DoFrameworkDetection(language *model.Language, goMod *modfile.File)
-	DoPortsDetection(component *model.Component)
+	DoPortsDetection(component *model.Component, ctx *context.Context)
 }
 
 func getGoFrameworkDetectors() []GoFrameworkDetector {
@@ -58,7 +59,7 @@ func (j GoEnricher) DoEnrichLanguage(language *model.Language, files *[]string) 
 	}
 }
 
-func (j GoEnricher) DoEnrichComponent(component *model.Component, settings model.DetectionSettings) {
+func (j GoEnricher) DoEnrichComponent(component *model.Component, settings model.DetectionSettings, ctx *context.Context) {
 	projectName := GetDefaultProjectName(component.Path)
 	component.Name = projectName
 
@@ -80,7 +81,7 @@ func (j GoEnricher) DoEnrichComponent(component *model.Component, settings model
 				for _, detector := range getGoFrameworkDetectors() {
 					for _, framework := range component.Languages[0].Frameworks {
 						if utils.Contains(detector.GetSupportedFrameworks(), framework) {
-							detector.DoPortsDetection(component)
+							detector.DoPortsDetection(component, ctx)
 						}
 					}
 				}

--- a/go/pkg/apis/enricher/java_enricher.go
+++ b/go/pkg/apis/enricher/java_enricher.go
@@ -11,6 +11,7 @@
 package enricher
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -53,7 +54,7 @@ func (j JavaEnricher) DoEnrichLanguage(language *model.Language, files *[]string
 	}
 }
 
-func (j JavaEnricher) DoEnrichComponent(component *model.Component, settings model.DetectionSettings) {
+func (j JavaEnricher) DoEnrichComponent(component *model.Component, settings model.DetectionSettings, ctx *context.Context) {
 	projectName := getProjectNameMaven(component.Path)
 	if projectName == "" {
 		projectName = getProjectNameGradle(component.Path)
@@ -81,7 +82,7 @@ func (j JavaEnricher) DoEnrichComponent(component *model.Component, settings mod
 				for _, detector := range getJavaFrameworkDetectors() {
 					for _, framework := range component.Languages[0].Frameworks {
 						if utils.Contains(detector.GetSupportedFrameworks(), framework) {
-							detector.DoPortsDetection(component)
+							detector.DoPortsDetection(component, ctx)
 						}
 					}
 				}

--- a/go/pkg/apis/enricher/javascript_enricher.go
+++ b/go/pkg/apis/enricher/javascript_enricher.go
@@ -17,6 +17,7 @@ import (
 	framework "github.com/redhat-developer/alizer/go/pkg/apis/enricher/framework/javascript/nodejs"
 	"github.com/redhat-developer/alizer/go/pkg/apis/model"
 	utils "github.com/redhat-developer/alizer/go/pkg/utils"
+	langfile "github.com/redhat-developer/alizer/go/pkg/utils/langfiles"
 )
 
 type JavaScriptEnricher struct{}
@@ -42,6 +43,17 @@ func (j JavaScriptEnricher) DoEnrichLanguage(language *model.Language, files *[]
 
 	if packageJson != "" {
 		language.Tools = []string{"NodeJs", "Node.js"}
+		var targetLanguage string
+		if utils.IsTagInPackageJsonFile(packageJson, "typescript") {
+			targetLanguage = "TypeScript"
+		} else {
+			targetLanguage = "JavaScript"
+		}
+		lang, err := langfile.Get().GetLanguageByName(targetLanguage)
+		if err == nil {
+			language.Name = lang.Name
+			language.Aliases = lang.Aliases
+		}
 		detectJavaScriptFrameworks(language, packageJson)
 	}
 }

--- a/go/pkg/apis/enricher/javascript_enricher.go
+++ b/go/pkg/apis/enricher/javascript_enricher.go
@@ -11,6 +11,7 @@
 package enricher
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 
@@ -58,7 +59,7 @@ func (j JavaScriptEnricher) DoEnrichLanguage(language *model.Language, files *[]
 	}
 }
 
-func (j JavaScriptEnricher) DoEnrichComponent(component *model.Component, settings model.DetectionSettings) {
+func (j JavaScriptEnricher) DoEnrichComponent(component *model.Component, settings model.DetectionSettings, ctx *context.Context) {
 	projectName := ""
 	packageJsonPath := filepath.Join(component.Path, "package.json")
 	if _, err := os.Stat(packageJsonPath); err == nil {
@@ -90,7 +91,7 @@ func (j JavaScriptEnricher) DoEnrichComponent(component *model.Component, settin
 				for _, detector := range getJavaScriptFrameworkDetectors() {
 					for _, framework := range component.Languages[0].Frameworks {
 						if utils.Contains(detector.GetSupportedFrameworks(), framework) {
-							detector.DoPortsDetection(component)
+							detector.DoPortsDetection(component, ctx)
 						}
 					}
 				}

--- a/go/pkg/apis/enricher/python_enricher.go
+++ b/go/pkg/apis/enricher/python_enricher.go
@@ -11,6 +11,8 @@
 package enricher
 
 import (
+	"context"
+
 	framework "github.com/redhat-developer/alizer/go/pkg/apis/enricher/framework/python"
 	"github.com/redhat-developer/alizer/go/pkg/apis/model"
 	utils "github.com/redhat-developer/alizer/go/pkg/utils"
@@ -33,7 +35,7 @@ func (p PythonEnricher) DoEnrichLanguage(language *model.Language, files *[]stri
 	detectPythonFrameworks(language, files)
 }
 
-func (j PythonEnricher) DoEnrichComponent(component *model.Component, settings model.DetectionSettings) {
+func (j PythonEnricher) DoEnrichComponent(component *model.Component, settings model.DetectionSettings, ctx *context.Context) {
 	projectName := GetDefaultProjectName(component.Path)
 	component.Name = projectName
 
@@ -55,7 +57,7 @@ func (j PythonEnricher) DoEnrichComponent(component *model.Component, settings m
 				for _, detector := range getPythonFrameworkDetectors() {
 					for _, framework := range component.Languages[0].Frameworks {
 						if utils.Contains(detector.GetSupportedFrameworks(), framework) {
-							detector.DoPortsDetection(component)
+							detector.DoPortsDetection(component, ctx)
 						}
 					}
 				}

--- a/go/pkg/apis/recognizer/devfile_recognizer.go
+++ b/go/pkg/apis/recognizer/devfile_recognizer.go
@@ -11,6 +11,7 @@
 package recognizer
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"io/ioutil"
@@ -22,6 +23,11 @@ import (
 )
 
 func SelectDevFileFromTypes(path string, devFileTypes []model.DevFileType) (int, error) {
+	ctx := context.Background()
+	return selectDevFileFromTypes(path, devFileTypes, &ctx)
+}
+
+func selectDevFileFromTypes(path string, devFileTypes []model.DevFileType, ctx *context.Context) (int, error) {
 	components, _ := DetectComponentsInRoot(path)
 	if len(components) > 0 {
 		devfile, err := selectDevFileByLanguage(components[0].Languages[0], devFileTypes)
@@ -38,7 +44,7 @@ func SelectDevFileFromTypes(path string, devFileTypes []model.DevFileType) (int,
 		}
 	}
 
-	languages, err := Analyze(path)
+	languages, err := analyze(path, ctx)
 	if err != nil {
 		return -1, err
 	}
@@ -60,12 +66,17 @@ func SelectDevFileUsingLanguagesFromTypes(languages []model.Language, devFileTyp
 }
 
 func SelectDevFileFromRegistry(path string, url string) (model.DevFileType, error) {
+	ctx := context.Background()
+	return selectDevFileFromRegistry(path, url, &ctx)
+}
+
+func selectDevFileFromRegistry(path string, url string, ctx *context.Context) (model.DevFileType, error) {
 	devFileTypes, err := downloadDevFileTypesFromRegistry(url)
 	if err != nil {
 		return model.DevFileType{}, err
 	}
 
-	index, err := SelectDevFileFromTypes(path, devFileTypes)
+	index, err := selectDevFileFromTypes(path, devFileTypes, ctx)
 	if err != nil {
 		return model.DevFileType{}, err
 	}

--- a/go/pkg/apis/recognizer/language_recognizer.go
+++ b/go/pkg/apis/recognizer/language_recognizer.go
@@ -11,6 +11,7 @@
 package recognizer
 
 import (
+	"context"
 	"path/filepath"
 	"sort"
 
@@ -26,10 +27,15 @@ type languageItem struct {
 }
 
 func Analyze(path string) ([]model.Language, error) {
+	ctx := context.Background()
+	return analyze(path, &ctx)
+}
+
+func analyze(path string, ctx *context.Context) ([]model.Language, error) {
 	languagesFile := langfile.Get()
 	languagesDetected := make(map[string]languageItem)
 
-	paths, err := utils.GetCachedFilePathsFromRoot(path)
+	paths, err := utils.GetCachedFilePathsFromRoot(path, ctx)
 	if err != nil {
 		return []model.Language{}, err
 	}

--- a/go/pkg/utils/cache.go
+++ b/go/pkg/utils/cache.go
@@ -1,8 +1,11 @@
 package utils
 
-var filePathsFromRoot = make(map[string][]string)
+import "context"
 
-func GetCachedFilePathsFromRoot(root string) ([]string, error) {
+type key string
+
+func GetCachedFilePathsFromRoot(root string, ctx *context.Context) ([]string, error) {
+	filePathsFromRoot := getMapFromContext(*ctx)
 	if files, hasRoot := filePathsFromRoot[root]; hasRoot {
 		return files, nil
 	}
@@ -12,5 +15,15 @@ func GetCachedFilePathsFromRoot(root string) ([]string, error) {
 		return []string{}, err
 	}
 	filePathsFromRoot[root] = filePaths
+
+	*ctx = context.WithValue(*ctx, key("mapFilePathsFromRoot"), filePathsFromRoot)
 	return filePaths, nil
+}
+
+func getMapFromContext(ctx context.Context) map[string][]string {
+	filePathsFromRoot := ctx.Value(key("mapFilePathsFromRoot"))
+	if filePathsFromRoot != nil {
+		return filePathsFromRoot.(map[string][]string)
+	}
+	return make(map[string][]string)
 }

--- a/go/pkg/utils/cache.go
+++ b/go/pkg/utils/cache.go
@@ -1,0 +1,16 @@
+package utils
+
+var filePathsFromRoot = make(map[string][]string)
+
+func GetCachedFilePathsFromRoot(root string) ([]string, error) {
+	if files, hasRoot := filePathsFromRoot[root]; hasRoot {
+		return files, nil
+	}
+
+	filePaths, err := GetFilePathsFromRoot(root)
+	if err != nil {
+		return []string{}, err
+	}
+	filePathsFromRoot[root] = filePaths
+	return filePaths, nil
+}

--- a/go/pkg/utils/detector.go
+++ b/go/pkg/utils/detector.go
@@ -13,6 +13,7 @@ package utils
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"encoding/json"
 	"encoding/xml"
 	"errors"
@@ -275,8 +276,8 @@ func IsValidPort(port int) bool {
 	return port > FROM_PORT && port < TO_PORT
 }
 
-func GetAnyApplicationFilePath(root string, propsFiles []model.ApplicationFileInfo) string {
-	files, err := GetCachedFilePathsFromRoot(root)
+func GetAnyApplicationFilePath(root string, propsFiles []model.ApplicationFileInfo, ctx *context.Context) string {
+	files, err := GetCachedFilePathsFromRoot(root, ctx)
 	if err != nil {
 		return ""
 	}
@@ -303,20 +304,20 @@ func GetAnyApplicationFilePathExactMatch(root string, propsFiles []model.Applica
 	return ""
 }
 
-func ReadAnyApplicationFile(root string, propsFiles []model.ApplicationFileInfo) ([]byte, error) {
-	return readAnyApplicationFile(root, propsFiles, false)
+func ReadAnyApplicationFile(root string, propsFiles []model.ApplicationFileInfo, ctx *context.Context) ([]byte, error) {
+	return readAnyApplicationFile(root, propsFiles, false, ctx)
 }
 
 func ReadAnyApplicationFileExactMatch(root string, propsFiles []model.ApplicationFileInfo) ([]byte, error) {
-	return readAnyApplicationFile(root, propsFiles, true)
+	return readAnyApplicationFile(root, propsFiles, true, nil)
 }
 
-func readAnyApplicationFile(root string, propsFiles []model.ApplicationFileInfo, exactMatch bool) ([]byte, error) {
+func readAnyApplicationFile(root string, propsFiles []model.ApplicationFileInfo, exactMatch bool, ctx *context.Context) ([]byte, error) {
 	var path string
 	if exactMatch {
 		path = GetAnyApplicationFilePathExactMatch(root, propsFiles)
 	} else {
-		path = GetAnyApplicationFilePath(root, propsFiles)
+		path = GetAnyApplicationFilePath(root, propsFiles, ctx)
 	}
 	if path != "" {
 		return ioutil.ReadFile(path)

--- a/go/test/apis/component_recognizer_test.go
+++ b/go/test/apis/component_recognizer_test.go
@@ -90,7 +90,7 @@ func TestComponentDetectionWithGitIgnoreRule(t *testing.T) {
 	settings := model.DetectionSettings{
 		BasePath: testingProjectPath,
 	}
-	files, err := utils.GetFilePathsFromRoot(testingProjectPath)
+	files, err := utils.GetCachedFilePathsFromRoot(testingProjectPath)
 	if err != nil {
 		t.Error(err)
 	}
@@ -107,7 +107,7 @@ func TestComponentDetectionWithGitIgnoreRule(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	files, err = utils.GetFilePathsFromRoot(testingProjectPath)
+	files, err = utils.GetCachedFilePathsFromRoot(testingProjectPath)
 	if err != nil {
 		t.Error(err)
 	}
@@ -162,12 +162,7 @@ func getComponentsFromProjectInner(t *testing.T, testingProjectPath string) []mo
 }
 
 func getComponentsFromFiles(t *testing.T, files []string, settings model.DetectionSettings) []model.Component {
-	components, err := recognizer.DetectComponentsFromFilesList(files, settings)
-	if err != nil {
-		t.Error(err)
-	}
-
-	return components
+	return recognizer.DetectComponentsFromFilesList(files, settings)
 }
 
 func isComponentsInProject(t *testing.T, project string, expectedNumber int, expectedLanguage string, expectedProjectName string) {

--- a/go/test/apis/component_recognizer_test.go
+++ b/go/test/apis/component_recognizer_test.go
@@ -11,6 +11,7 @@
 package recognizer
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -90,7 +91,8 @@ func TestComponentDetectionWithGitIgnoreRule(t *testing.T) {
 	settings := model.DetectionSettings{
 		BasePath: testingProjectPath,
 	}
-	files, err := utils.GetCachedFilePathsFromRoot(testingProjectPath)
+	ctx := context.Background()
+	files, err := utils.GetCachedFilePathsFromRoot(testingProjectPath, &ctx)
 	if err != nil {
 		t.Error(err)
 	}
@@ -107,7 +109,7 @@ func TestComponentDetectionWithGitIgnoreRule(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	files, err = utils.GetCachedFilePathsFromRoot(testingProjectPath)
+	files, err = utils.GetCachedFilePathsFromRoot(testingProjectPath, &ctx)
 	if err != nil {
 		t.Error(err)
 	}
@@ -162,7 +164,8 @@ func getComponentsFromProjectInner(t *testing.T, testingProjectPath string) []mo
 }
 
 func getComponentsFromFiles(t *testing.T, files []string, settings model.DetectionSettings) []model.Component {
-	return recognizer.DetectComponentsFromFilesList(files, settings)
+	ctx := context.Background()
+	return recognizer.DetectComponentsFromFilesList(files, settings, &ctx)
 }
 
 func isComponentsInProject(t *testing.T, project string, expectedNumber int, expectedLanguage string, expectedProjectName string) {


### PR DESCRIPTION
it resolves #118 

This patch refactored some aspects of the detection to improve its speed. In some cases it went from 1m to less than 1 sec.

- fetching all files is now cached
- finding a file also works using an exact location, so it skips from running a regex on each path and it just look at that position (dir + filename) to check if it exists
- when performing a root detection, alizer still was fetching all files even if it was not needed and i removed the `no-config` languages detection from the root detection as it's useless. it needs to parse all files.