### PR TITLE
chore: extend test suite

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -84,4 +84,4 @@ jobs:
           cd go
           make init
           go mod tidy -compat=1.17
-          go test -v test/apis/language_recognizer_test.go
+          go test ./...

--- a/go/pkg/apis/enricher/framework/javascript/nodejs/next_detector.go
+++ b/go/pkg/apis/enricher/framework/javascript/nodejs/next_detector.go
@@ -36,7 +36,7 @@ func (n NextDetector) DoPortsDetection(component *model.Component) {
 		return
 	}
 
-	// check if port is set in start script in package.json
+	// check if port is set in dev script in package.json
 	port = getPortFromDevScript(component.Path, regexes)
 	if utils.IsValidPort(port) {
 		component.Ports = []int{port}

--- a/go/pkg/apis/enricher/java_enricher.go
+++ b/go/pkg/apis/enricher/java_enricher.go
@@ -143,8 +143,8 @@ func isParentModuleMaven(configPath string) bool {
 		return false
 	}
 
-	hasTag, _ := utils.IsTagInPomXMLFile(configPath, "modules")
-	return hasTag
+	pomContent, _ := utils.GetPomFileContent(configPath)
+	return pomContent.Modules.Module != ""
 }
 
 func detectJavaFrameworks(language *model.Language, configFile string) {

--- a/go/pkg/schema/package_json.go
+++ b/go/pkg/schema/package_json.go
@@ -13,6 +13,7 @@ package schema
 type PackageJson struct {
 	Name             string            `json:"name"`
 	Dependencies     map[string]string `json:"dependencies"`
+	DevDependencies  map[string]string `json:"devDependencies"`
 	PeerDependencies map[string]string `json:"peerDependencies"`
 	Scripts          Script            `json:"scripts"`
 }

--- a/go/pkg/utils/detector.go
+++ b/go/pkg/utils/detector.go
@@ -116,15 +116,20 @@ func IsTagInPackageJsonFile(file string, tag string) bool {
 	if err != nil {
 		return false
 	}
-	if packageJson.Dependencies != nil {
-		for dependency := range packageJson.Dependencies {
-			if strings.Contains(dependency, tag) {
-				return true
-			}
-		}
+
+	hasDependency := isTagInDependencies(packageJson.Dependencies, tag)
+	if !hasDependency {
+		hasDependency = isTagInDependencies(packageJson.DevDependencies, tag)
 	}
-	if packageJson.PeerDependencies != nil {
-		for dependency := range packageJson.PeerDependencies {
+	if !hasDependency {
+		hasDependency = isTagInDependencies(packageJson.PeerDependencies, tag)
+	}
+	return hasDependency
+}
+
+func isTagInDependencies(deps map[string]string, tag string) bool {
+	if deps != nil {
+		for dependency := range deps {
 			if strings.Contains(dependency, tag) {
 				return true
 			}

--- a/go/test/apis/git_recognizer_test.go
+++ b/go/test/apis/git_recognizer_test.go
@@ -67,18 +67,6 @@ func checkoutAndTest(resChan chan resultTest, repo string, properties test.GitTe
 
 }
 
-/*func checkoutAndTest(t *testing.T, repo string, properties test.GitTestProperties) error {
-	root, err := test.CheckoutCommit(repo, properties.Commit)
-	defer os.RemoveAll(root)
-	if err != nil {
-		return err
-	} else {
-		dir := filepath.Join(root, properties.Directory)
-		assertComponentsBelongToGitProject(t, dir, properties.Components)
-	}
-	return nil
-}*/
-
 func assertComponentsBelongToGitProject(gitProjectPath string, expectedComponents []test.ComponentProperties) []error {
 	components, err := recognizer.DetectComponents(gitProjectPath)
 	if err != nil {

--- a/go/test/apis/git_recognizer_test.go
+++ b/go/test/apis/git_recognizer_test.go
@@ -10,7 +10,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/pkg/errors"
 	"github.com/redhat-developer/alizer/go/pkg/apis/model"
+	"github.com/redhat-developer/alizer/go/pkg/apis/recognizer"
 	"github.com/redhat-developer/alizer/go/pkg/utils"
 	"github.com/redhat-developer/alizer/go/test"
 )
@@ -27,16 +29,45 @@ func TestExternalRepos(t *testing.T) {
 		t.Fatal("Unable to fetch git repositories file to run tests to")
 	}
 
+	resChan := make(chan resultTest)
 	// loop over all repositories and verify expected results are correct
 	for repo, properties := range data {
-		err := checkoutAndTest(t, repo, properties)
-		if err != nil {
-			t.Errorf("Unable to download git repo %s", err.Error())
-		}
+		checkoutAndTest(resChan, repo, properties)
 	}
 
+	for i := 1; i <= len(data); i++ {
+		result := <-resChan
+		os.RemoveAll(result.root)
+		for _, err := range result.errors {
+			t.Error(err)
+		}
+	}
 }
-func checkoutAndTest(t *testing.T, repo string, properties test.GitTestProperties) error {
+
+type resultTest struct {
+	root   string
+	errors []error
+}
+
+func checkoutAndTest(resChan chan resultTest, repo string, properties test.GitTestProperties) {
+	go func() {
+		root, err := test.CheckoutCommit(repo, properties.Commit)
+		var errs []error
+		if err != nil {
+			errs = []error{err}
+		} else {
+			dir := filepath.Join(root, properties.Directory)
+			errs = assertComponentsBelongToGitProject(dir, properties.Components)
+		}
+		resChan <- resultTest{
+			root:   root,
+			errors: errs,
+		}
+	}()
+
+}
+
+/*func checkoutAndTest(t *testing.T, repo string, properties test.GitTestProperties) error {
 	root, err := test.CheckoutCommit(repo, properties.Commit)
 	defer os.RemoveAll(root)
 	if err != nil {
@@ -46,10 +77,14 @@ func checkoutAndTest(t *testing.T, repo string, properties test.GitTestPropertie
 		assertComponentsBelongToGitProject(t, dir, properties.Components)
 	}
 	return nil
-}
+}*/
 
-func assertComponentsBelongToGitProject(t *testing.T, gitProjectPath string, expectedComponents []test.ComponentProperties) {
-	components := getComponentsFromProjectInner(t, gitProjectPath)
+func assertComponentsBelongToGitProject(gitProjectPath string, expectedComponents []test.ComponentProperties) []error {
+	components, err := recognizer.DetectComponents(gitProjectPath)
+	if err != nil {
+		return []error{err}
+	}
+	errs := []error{}
 	assertNumberOfComponents := len(components) == len(expectedComponents)
 	if assertNumberOfComponents {
 		// sort both slices by component name
@@ -63,23 +98,24 @@ func assertComponentsBelongToGitProject(t *testing.T, gitProjectPath string, exp
 		cont := 0
 		for cont < len(components) {
 			if expectedComponents[cont].Name != "ignore" && !strings.EqualFold(components[cont].Name, expectedComponents[cont].Name) {
-				t.Errorf("Expected to find component %s but it was found %s", expectedComponents[cont].Name, components[cont].Name)
+				errs = append(errs, errors.Errorf("Expected to find component %s but it was found %s", expectedComponents[cont].Name, components[cont].Name))
 			}
 			if !assertExpectedLangsAreFound(expectedComponents[cont].Languages, components[cont].Languages) {
 				expectedPretty := printPrettyStruct(expectedComponents[cont].Languages)
 				foundPretty := printPrettyStruct(components[cont].Languages)
-				t.Errorf("Languages found are different from those expected.\nExpected: %s\nFound: %s ", expectedPretty, foundPretty)
+				errs = append(errs, errors.Errorf("Languages found are different from those expected.\nExpected: %s\nFound: %s ", expectedPretty, foundPretty))
 			}
 			if !assertExpectedPortsAreFound(expectedComponents[cont].Ports, components[cont].Ports) {
 				expectedPretty := printPrettyStruct(expectedComponents[cont].Ports)
 				foundPretty := printPrettyStruct(components[cont].Ports)
-				t.Errorf("Ports found are different from those expected.\nExpected: %s\nFound: %s ", expectedPretty, foundPretty)
+				errs = append(errs, errors.Errorf("Ports found are different from those expected.\nExpected: %s\nFound: %s ", expectedPretty, foundPretty))
 			}
 			cont++
 		}
 	} else {
-		t.Errorf("Expected " + strconv.Itoa(len(expectedComponents)) + " components but they were " + strconv.Itoa(len(components)))
+		errs = append(errs, errors.Errorf("Expected "+strconv.Itoa(len(expectedComponents))+" components but they were "+strconv.Itoa(len(components))))
 	}
+	return errs
 }
 
 func printPrettyStruct(v interface{}) string {

--- a/go/test/apis/git_recognizer_test.go
+++ b/go/test/apis/git_recognizer_test.go
@@ -29,16 +29,23 @@ func TestExternalRepos(t *testing.T) {
 
 	// loop over all repositories and verify expected results are correct
 	for repo, properties := range data {
-		root, err := test.CheckoutCommit(repo, properties.Commit)
-		defer os.RemoveAll(root)
+		err := checkoutAndTest(t, repo, properties)
 		if err != nil {
 			t.Errorf("Unable to download git repo %s", err.Error())
-		} else {
-			dir := filepath.Join(root, properties.Directory)
-			assertComponentsBelongToGitProject(t, dir, properties.Components)
 		}
 	}
 
+}
+func checkoutAndTest(t *testing.T, repo string, properties test.GitTestProperties) error {
+	root, err := test.CheckoutCommit(repo, properties.Commit)
+	defer os.RemoveAll(root)
+	if err != nil {
+		return err
+	} else {
+		dir := filepath.Join(root, properties.Directory)
+		assertComponentsBelongToGitProject(t, dir, properties.Components)
+	}
+	return nil
 }
 
 func assertComponentsBelongToGitProject(t *testing.T, gitProjectPath string, expectedComponents []test.ComponentProperties) {

--- a/go/test/git_test.json
+++ b/go/test/git_test.json
@@ -484,5 +484,73 @@
                 ]
             }
         ]
+    },
+    "https://github.com/JoranBergfeld/webshop.git": {
+        "commit": "7cbd9ddd2207dd712369e44da56699c9393765c8",
+        "components": [
+            {
+                "name": "webshop",
+                "languages": [
+                    {
+                        "name": "Java",
+                        "frameworks": [],
+                        "tools": [
+                            "Maven"
+                        ]
+                    }
+                ]
+            },
+            {
+                "name": "order-app",
+                "languages": [
+                    {
+                        "name": "Java",
+                        "frameworks": [
+                            "Spring"
+                        ],
+                        "tools": [
+                            "Maven"
+                        ]
+                    }
+                ],
+                "ports": [
+                    "15000"
+                ]
+            },
+            {
+                "name": "payment-app",
+                "languages": [
+                    {
+                        "name": "Java",
+                        "frameworks": [
+                            "Spring"
+                        ],
+                        "tools": [
+                            "Maven"
+                        ]
+                    }
+                ],
+                "ports": [
+                    "15001"
+                ]
+            },
+            {
+                "name": "stock-app",
+                "languages": [
+                    {
+                        "name": "Java",
+                        "frameworks": [
+                            "Spring"
+                        ],
+                        "tools": [
+                            "Maven"
+                        ]
+                    }
+                ],
+                "ports": [
+                    "15002"
+                ]
+            }
+        ]
     }
 }

--- a/go/test/git_test.json
+++ b/go/test/git_test.json
@@ -679,6 +679,370 @@
                     ]
                 }
             ]
+        },
+        "https://github.com/bucharest-gold/s2i-nodejs.git": {
+            "commit": "c7f990e02a14560b756187dd8ad21d6eb74246d9",
+            "components": [
+                {
+                    "name": "s2i-nodejs",
+                    "languages": [
+                        {
+                            "name": "JavaScript",
+                            "frameworks": [ ],
+                            "tools": [
+                                "NodeJs",
+                                "Node.js"
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        "https://github.com/nodeshift-starters/opossum-examples.git": {
+            "commit": "821451be248a78dbd58a21f2f2e661ab332bf7ed",
+            "components": [
+                {
+                    "name": "angular",
+                    "languages": [
+                        {
+                            "name": "TypeScript",
+                            "frameworks": [
+                                "Angular"
+                            ],
+                            "tools": [
+                                "NodeJs",
+                                "Node.js"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "opossum-angular",
+                    "languages": [
+                        {
+                            "name": "TypeScript",
+                            "frameworks": [
+                                "Express"
+                            ],
+                            "tools": [
+                                "NodeJs",
+                                "Node.js"
+                            ]
+                        }
+                    ],
+                    "ports": [
+                        "3000"
+                    ]
+                },
+                {
+                    "name": "ember-opossum",
+                    "languages": [
+                        {
+                            "name": "JavaScript",
+                            "frameworks": [ ],
+                            "tools": [
+                                "NodeJs",
+                                "Node.js"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "opossum-browser-example",
+                    "languages": [
+                        {
+                            "name": "JavaScript",
+                            "frameworks": [ ],
+                            "tools": [
+                                "NodeJs",
+                                "Node.js"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "database-timeout",
+                    "languages": [
+                        {
+                            "name": "JavaScript",
+                            "frameworks": [
+                                "Express"
+                            ],
+                            "tools": [
+                                "NodeJs",
+                                "Node.js"
+                            ]
+                        }
+                    ],
+                    "ports": [
+                        "3000"
+                    ]
+                },
+                {
+                    "name": "multiple-express",
+                    "languages": [
+                        {
+                            "name": "JavaScript",
+                            "frameworks": [
+                                "Express"
+                            ],
+                            "tools": [
+                                "NodeJs",
+                                "Node.js"
+                            ]
+                        }
+                    ],
+                    "ports": [
+                        "8080"
+                    ]
+                },
+                {
+                    "name": "typescript-example",
+                    "languages": [
+                        {
+                            "name": "TypeScript",
+                            "frameworks": [ ],
+                            "tools": [
+                                "NodeJs",
+                                "Node.js"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "express-prometheus-minishift",
+                    "languages": [
+                        {
+                            "name": "JavaScript",
+                            "frameworks": [
+                                "Express"
+                            ],
+                            "tools": [
+                                "NodeJs",
+                                "Node.js"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "opossum-react-client",
+                    "languages": [
+                        {
+                            "name": "JavaScript",
+                            "frameworks": [
+                                "React"
+                            ],
+                            "tools": [
+                                "NodeJs",
+                                "Node.js"
+                            ]
+                        }
+                    ],
+                    "ports": [
+                        "8080"
+                    ]
+                },
+                {
+                    "name": "opossum-react",
+                    "languages": [
+                        {
+                            "name": "JavaScript",
+                            "frameworks": [
+                                "Express"
+                            ],
+                            "tools": [
+                                "NodeJs",
+                                "Node.js"
+                            ]
+                        }
+                    ],
+                    "ports": [
+                        "3000"
+                    ]
+                },
+                {
+                    "name": "opossum-browser-example",
+                    "languages": [
+                        {
+                            "name": "JavaScript",
+                            "frameworks": [ ],
+                            "tools": [
+                                "NodeJs",
+                                "Node.js"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "svelte-app",
+                    "languages": [
+                        {
+                            "name": "JavaScript",
+                            "frameworks": [ 
+                                "Svelte"
+                            ],
+                            "tools": [
+                                "NodeJs",
+                                "Node.js"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "opossum-svelte",
+                    "languages": [
+                        {
+                            "name": "JavaScript",
+                            "frameworks": [ 
+                                "Express"
+                            ],
+                            "tools": [
+                                "NodeJs",
+                                "Node.js"
+                            ]
+                        }
+                    ],
+                    "ports": [
+                        "3000"
+                    ]
+                },
+                {
+                    "name": "opossum-vue-client",
+                    "languages": [
+                        {
+                            "name": "JavaScript",
+                            "frameworks": [ 
+                                "Vue"
+                            ],
+                            "tools": [
+                                "NodeJs",
+                                "Node.js"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "opossum-vue",
+                    "languages": [
+                        {
+                            "name": "JavaScript",
+                            "frameworks": [ 
+                                "Express"
+                            ],
+                            "tools": [
+                                "NodeJs",
+                                "Node.js"
+                            ]
+                        }
+                    ],
+                    "ports": [
+                        "3000"
+                    ]
+                }
+            ]
+        },
+        "https://github.com/nodeshift-starters/nodejs-rest-http.git": {
+            "commit": "7b16266ce25bf4392c8f9a3a13f8fff76890ed05",
+            "components": [
+                {
+                    "name": "nodejs-rest-http",
+                    "languages": [
+                        {
+                            "name": "JavaScript",
+                            "frameworks": [ 
+                                "Express"
+                            ],
+                            "tools": [
+                                "NodeJs",
+                                "Node.js"
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        "https://github.com/nodeshift-starters/nodejs-circuit-breaker.git": {
+            "commit": "1879d4d716487890ecb6f98bf50aa44b8cc6f4c8",
+            "components": [
+                {
+                    "name": "nodejs-circuit-breaker-greeting",
+                    "languages": [
+                        {
+                            "name": "JavaScript",
+                            "frameworks": [ 
+                                "Express"
+                            ],
+                            "tools": [
+                                "NodeJs",
+                                "Node.js"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "nodejs-circuit-breaker-name",
+                    "languages": [
+                        {
+                            "name": "JavaScript",
+                            "frameworks": [ 
+                                "Express"
+                            ],
+                            "tools": [
+                                "NodeJs",
+                                "Node.js"
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        "https://github.com/nodeshift-starters/reactive-example.git": {
+            "commit": "86d452aaa1170a710b33227965b0828f6c5d78af",
+            "components": [
+                {
+                    "name": "consumer-backend",
+                    "languages": [
+                        {
+                            "name": "JavaScript",
+                            "frameworks": [ 
+                                "Express"
+                            ],
+                            "tools": [
+                                "NodeJs",
+                                "Node.js"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "frontend",
+                    "languages": [
+                        {
+                            "name": "JavaScript",
+                            "frameworks": [ 
+                                "Express"
+                            ],
+                            "tools": [
+                                "NodeJs",
+                                "Node.js"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "producer-backend",
+                    "languages": [
+                        {
+                            "name": "JavaScript",
+                            "frameworks": [ ],
+                            "tools": [
+                                "NodeJs",
+                                "Node.js"
+                            ]
+                        }
+                    ]
+                }
+            ]
         }
     }
 }

--- a/go/test/git_test.json
+++ b/go/test/git_test.json
@@ -1145,6 +1145,96 @@
                     ]
                 }
             ]
+        },
+        "https://github.com/nodeshift-starters/nodejs-configmap.git": {
+            "commit": "9710d7a74d995de3322e378d43528706c5d5f085",
+            "components": [
+                {
+                    "name": "nodejs-configmap",
+                    "languages": [
+                        {
+                            "name": "JavaScript",
+                            "frameworks": [ 
+                                "Express"
+                            ],
+                            "tools": [
+                                "NodeJs",
+                                "Node.js"
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        "https://github.com/nodeshift-starters/nodejs-messaging-work-queue.git": {
+            "commit": "5b95d6fc6c004a205cb2e966a4f78da736dfb44e",
+            "components": [
+                {
+                    "name": "nodejs-messaging-work-queue-frontend",
+                    "languages": [
+                        {
+                            "name": "JavaScript",
+                            "frameworks": [ 
+                                "Express"
+                            ],
+                            "tools": [
+                                "NodeJs",
+                                "Node.js"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "nodejs-messaging-work-queue-worker",
+                    "languages": [
+                        {
+                            "name": "JavaScript",
+                            "frameworks": [ 
+                                "Express"
+                            ],
+                            "tools": [
+                                "NodeJs",
+                                "Node.js"
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        "https://github.com/nodeshift-starters/nodejs-cache.git": {
+            "commit": "8059b4520e07d3ffaec5c3759b918d86c8b574de",
+            "components": [
+                {
+                    "name": "nodejs-cache-cute-name",
+                    "languages": [
+                        {
+                            "name": "JavaScript",
+                            "frameworks": [ 
+                                "Express"
+                            ],
+                            "tools": [
+                                "NodeJs",
+                                "Node.js"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "nodejs-cache-greeting",
+                    "languages": [
+                        {
+                            "name": "JavaScript",
+                            "frameworks": [ 
+                                "Express"
+                            ],
+                            "tools": [
+                                "NodeJs",
+                                "Node.js"
+                            ]
+                        }
+                    ]
+                }
+            ]
         }
     }
 }

--- a/go/test/git_test.json
+++ b/go/test/git_test.json
@@ -489,18 +489,6 @@
         "commit": "7cbd9ddd2207dd712369e44da56699c9393765c8",
         "components": [
             {
-                "name": "webshop",
-                "languages": [
-                    {
-                        "name": "Java",
-                        "frameworks": [],
-                        "tools": [
-                            "Maven"
-                        ]
-                    }
-                ]
-            },
-            {
                 "name": "order-app",
                 "languages": [
                     {
@@ -514,7 +502,7 @@
                     }
                 ],
                 "ports": [
-                    "15000"
+                    15000
                 ]
             },
             {
@@ -531,7 +519,7 @@
                     }
                 ],
                 "ports": [
-                    "15001"
+                    15001
                 ]
             },
             {
@@ -548,693 +536,706 @@
                     }
                 ],
                 "ports": [
-                    "15002"
+                    15002
                 ]
             }
-        ],
-        "https://github.com/bezkoder/spring-boot-data-jpa-mysql.git": {
-            "commit": "75d0e3b13635a9a7a5e5a1c6b02c04366476227a",
-            "components": [
-                {
-                    "name": "spring-boot-data-jpa",
-                    "languages": [
-                        {
-                            "name": "Java",
-                            "frameworks": [
-                                "Spring"
-                            ],
-                            "tools": [
-                                "Maven"
-                            ]
-                        }
-                    ]
-                }
-            ]
-        },
-        "https://github.com/kylebuch8/urgent-care-finder-v2.git": {
-            "commit": "c9a32ce6f53bec3b915991bb4fe95ffd7bce8e2b",
-            "components": [
-                {
-                    "name": "nextjs",
-                    "languages": [
-                        {
-                            "name": "JavaScript",
-                            "frameworks": [
-                                "Next",
-                                "Next.js",
-                                "React"
-                            ],
-                            "tools": [
-                                "NodeJs",
-                                "Node.js"
-                            ]
-                        }
-                    ]
-                }
-            ]
-        },
-        "https://github.com/rh-aiservices-bu/object-detection-rest.git": {
-            "commit": "cd9b8b573518c3080e3ce60f61255b9e9e164f6e",
-            "components": [
-                {
-                    "name": "object-detection-rest",
-                    "languages": [
-                        {
-                            "name": "Python",
-                            "frameworks": [],
-                            "tools": []
-                        }
-                    ]
-                }
-            ]
-        },
-        "https://github.com/gothinkster/spring-boot-realworld-example-app.git": {
-            "commit": "ee17e31aafe733d98c4853c8b9a74d7f2f6c924a",
-            "components": [
-                {
-                    "name": "spring-boot-realworld-example-app",
-                    "languages": [
-                        {
-                            "name": "Java",
-                            "frameworks": [
-                                "Spring"
-                            ],
-                            "tools": [
-                                "Gradle"
-                            ]
-                        }
-                    ]
-                }
-            ]
-        },
-        "https://github.com/spring-guides/gs-batch-processing.git": {
-            "commit": "19b0881fe060f15553d50aaef18a372735f2253d",
-            "components": [
-                {
-                    "name": "batch-processing-complete",
-                    "languages": [
-                        {
-                            "name": "Java",
-                            "frameworks": [
-                                "Spring"
-                            ],
-                            "tools": [
-                                "Gradle"
-                            ]
-                        }
-                    ]
-                },
-                {
-                    "name": "batch-processing-initial",
-                    "languages": [
-                        {
-                            "name": "Java",
-                            "frameworks": [
-                                "Spring"
-                            ],
-                            "tools": [
-                                "Gradle"
-                            ]
-                        }
-                    ]
-                }
-            ]
-        },
-        "https://github.com/patternfly/patternfly-react-seed.git": {
-            "commit": "62e92b78a64c93f3fa8c059e7482aaa3192e681d",
-            "components": [
-                {
-                    "name": "patternfly-seed",
-                    "languages": [
-                        {
-                            "name": "TypeScript",
-                            "frameworks": [
-                                "React"
-                            ],
-                            "tools": [
-                                "NodeJs",
-                                "Node.js"
-                            ]
-                        }
-                    ]
-                }
-            ]
-        },
-        "https://github.com/bucharest-gold/s2i-nodejs.git": {
-            "commit": "c7f990e02a14560b756187dd8ad21d6eb74246d9",
-            "components": [
-                {
-                    "name": "s2i-nodejs",
-                    "languages": [
-                        {
-                            "name": "JavaScript",
-                            "frameworks": [ ],
-                            "tools": [
-                                "NodeJs",
-                                "Node.js"
-                            ]
-                        }
-                    ]
-                }
-            ]
-        },
-        "https://github.com/nodeshift-starters/opossum-examples.git": {
-            "commit": "821451be248a78dbd58a21f2f2e661ab332bf7ed",
-            "components": [
-                {
-                    "name": "angular",
-                    "languages": [
-                        {
-                            "name": "TypeScript",
-                            "frameworks": [
-                                "Angular"
-                            ],
-                            "tools": [
-                                "NodeJs",
-                                "Node.js"
-                            ]
-                        }
-                    ]
-                },
-                {
-                    "name": "opossum-angular",
-                    "languages": [
-                        {
-                            "name": "TypeScript",
-                            "frameworks": [
-                                "Express"
-                            ],
-                            "tools": [
-                                "NodeJs",
-                                "Node.js"
-                            ]
-                        }
-                    ],
-                    "ports": [
-                        "3000"
-                    ]
-                },
-                {
-                    "name": "ember-opossum",
-                    "languages": [
-                        {
-                            "name": "JavaScript",
-                            "frameworks": [ ],
-                            "tools": [
-                                "NodeJs",
-                                "Node.js"
-                            ]
-                        }
-                    ]
-                },
-                {
-                    "name": "opossum-browser-example",
-                    "languages": [
-                        {
-                            "name": "JavaScript",
-                            "frameworks": [ ],
-                            "tools": [
-                                "NodeJs",
-                                "Node.js"
-                            ]
-                        }
-                    ]
-                },
-                {
-                    "name": "database-timeout",
-                    "languages": [
-                        {
-                            "name": "JavaScript",
-                            "frameworks": [
-                                "Express"
-                            ],
-                            "tools": [
-                                "NodeJs",
-                                "Node.js"
-                            ]
-                        }
-                    ],
-                    "ports": [
-                        "3000"
-                    ]
-                },
-                {
-                    "name": "multiple-express",
-                    "languages": [
-                        {
-                            "name": "JavaScript",
-                            "frameworks": [
-                                "Express"
-                            ],
-                            "tools": [
-                                "NodeJs",
-                                "Node.js"
-                            ]
-                        }
-                    ],
-                    "ports": [
-                        "8080"
-                    ]
-                },
-                {
-                    "name": "typescript-example",
-                    "languages": [
-                        {
-                            "name": "TypeScript",
-                            "frameworks": [ ],
-                            "tools": [
-                                "NodeJs",
-                                "Node.js"
-                            ]
-                        }
-                    ]
-                },
-                {
-                    "name": "express-prometheus-minishift",
-                    "languages": [
-                        {
-                            "name": "JavaScript",
-                            "frameworks": [
-                                "Express"
-                            ],
-                            "tools": [
-                                "NodeJs",
-                                "Node.js"
-                            ]
-                        }
-                    ]
-                },
-                {
-                    "name": "opossum-react-client",
-                    "languages": [
-                        {
-                            "name": "JavaScript",
-                            "frameworks": [
-                                "React"
-                            ],
-                            "tools": [
-                                "NodeJs",
-                                "Node.js"
-                            ]
-                        }
-                    ],
-                    "ports": [
-                        "8080"
-                    ]
-                },
-                {
-                    "name": "opossum-react",
-                    "languages": [
-                        {
-                            "name": "JavaScript",
-                            "frameworks": [
-                                "Express"
-                            ],
-                            "tools": [
-                                "NodeJs",
-                                "Node.js"
-                            ]
-                        }
-                    ],
-                    "ports": [
-                        "3000"
-                    ]
-                },
-                {
-                    "name": "opossum-browser-example",
-                    "languages": [
-                        {
-                            "name": "JavaScript",
-                            "frameworks": [ ],
-                            "tools": [
-                                "NodeJs",
-                                "Node.js"
-                            ]
-                        }
-                    ]
-                },
-                {
-                    "name": "svelte-app",
-                    "languages": [
-                        {
-                            "name": "JavaScript",
-                            "frameworks": [ 
-                                "Svelte"
-                            ],
-                            "tools": [
-                                "NodeJs",
-                                "Node.js"
-                            ]
-                        }
-                    ]
-                },
-                {
-                    "name": "opossum-svelte",
-                    "languages": [
-                        {
-                            "name": "JavaScript",
-                            "frameworks": [ 
-                                "Express"
-                            ],
-                            "tools": [
-                                "NodeJs",
-                                "Node.js"
-                            ]
-                        }
-                    ],
-                    "ports": [
-                        "3000"
-                    ]
-                },
-                {
-                    "name": "opossum-vue-client",
-                    "languages": [
-                        {
-                            "name": "JavaScript",
-                            "frameworks": [ 
-                                "Vue"
-                            ],
-                            "tools": [
-                                "NodeJs",
-                                "Node.js"
-                            ]
-                        }
-                    ]
-                },
-                {
-                    "name": "opossum-vue",
-                    "languages": [
-                        {
-                            "name": "JavaScript",
-                            "frameworks": [ 
-                                "Express"
-                            ],
-                            "tools": [
-                                "NodeJs",
-                                "Node.js"
-                            ]
-                        }
-                    ],
-                    "ports": [
-                        "3000"
-                    ]
-                }
-            ]
-        },
-        "https://github.com/nodeshift-starters/nodejs-rest-http.git": {
-            "commit": "7b16266ce25bf4392c8f9a3a13f8fff76890ed05",
-            "components": [
-                {
-                    "name": "nodejs-rest-http",
-                    "languages": [
-                        {
-                            "name": "JavaScript",
-                            "frameworks": [ 
-                                "Express"
-                            ],
-                            "tools": [
-                                "NodeJs",
-                                "Node.js"
-                            ]
-                        }
-                    ]
-                }
-            ]
-        },
-        "https://github.com/nodeshift-starters/nodejs-circuit-breaker.git": {
-            "commit": "1879d4d716487890ecb6f98bf50aa44b8cc6f4c8",
-            "components": [
-                {
-                    "name": "nodejs-circuit-breaker-greeting",
-                    "languages": [
-                        {
-                            "name": "JavaScript",
-                            "frameworks": [ 
-                                "Express"
-                            ],
-                            "tools": [
-                                "NodeJs",
-                                "Node.js"
-                            ]
-                        }
-                    ]
-                },
-                {
-                    "name": "nodejs-circuit-breaker-name",
-                    "languages": [
-                        {
-                            "name": "JavaScript",
-                            "frameworks": [ 
-                                "Express"
-                            ],
-                            "tools": [
-                                "NodeJs",
-                                "Node.js"
-                            ]
-                        }
-                    ]
-                }
-            ]
-        },
-        "https://github.com/nodeshift-starters/reactive-example.git": {
-            "commit": "86d452aaa1170a710b33227965b0828f6c5d78af",
-            "components": [
-                {
-                    "name": "consumer-backend",
-                    "languages": [
-                        {
-                            "name": "JavaScript",
-                            "frameworks": [ 
-                                "Express"
-                            ],
-                            "tools": [
-                                "NodeJs",
-                                "Node.js"
-                            ]
-                        }
-                    ]
-                },
-                {
-                    "name": "frontend",
-                    "languages": [
-                        {
-                            "name": "JavaScript",
-                            "frameworks": [ 
-                                "Express"
-                            ],
-                            "tools": [
-                                "NodeJs",
-                                "Node.js"
-                            ]
-                        }
-                    ]
-                },
-                {
-                    "name": "producer-backend",
-                    "languages": [
-                        {
-                            "name": "JavaScript",
-                            "frameworks": [ ],
-                            "tools": [
-                                "NodeJs",
-                                "Node.js"
-                            ]
-                        }
-                    ]
-                }
-            ]
-        },
-        "https://github.com/nodeshift-starters/nodejs-health-check.git": {
-            "commit": "8748b233c56b0f85a6a5e9a66a1caa60fb8cb3d1",
-            "components": [
-                {
-                    "name": "nodejs-health-check",
-                    "languages": [
-                        {
-                            "name": "JavaScript",
-                            "frameworks": [ 
-                                "Express"
-                            ],
-                            "tools": [
-                                "NodeJs",
-                                "Node.js"
-                            ]
-                        }
-                    ]
-                }
-            ]
-        },
-        "https://github.com/burrsutter/todo-apps.git": {
-            "commit": "9d03c47a15f9e4a651eac20b48cd8c6143d34815",
-            "directory": "quarkus-todo",
-            "components": [
-                {
-                    "name": "quarkus-todo",
-                    "languages": [
-                        {
-                            "name": "Java",
-                            "frameworks": [ 
-                                "Quarkus"
-                            ],
-                            "tools": [
-                                "Maven"
-                            ]
-                        }
-                    ]
-                },
-                {
-                    "name": "resources",
-                    "languages": [
-                        {
-                            "name": "JavaScript",
-                            "frameworks": [ 
-                                "Vue"
-                            ],
-                            "tools": [
-                                "NodeJs",
-                                "Node.js"
-                            ]
-                        }
-                    ]
-                }
-            ]
-        },
-        "https://github.com/marcnuri-demo/jkube-remote-dev.git": {
-            "commit": "c56bb2124732180a5c5cc37217d1a07cd4119e4c",
-            "components": [
-                {
-                    "name": "mail",
-                    "languages": [
-                        {
-                            "name": "Java",
-                            "frameworks": [ 
-                                "Micronaut"
-                            ],
-                            "tools": [
-                                "Maven"
-                            ]
-                        }
-                    ]
-                },
-                {
-                    "name": "northwind",
-                    "languages": [
-                        {
-                            "name": "Java",
-                            "frameworks": [ 
-                                "Quarkus"
-                            ],
-                            "tools": [
-                                "Maven"
-                            ]
-                        }
-                    ]
-                },
-                {
-                    "name": "order-faker",
-                    "languages": [
-                        {
-                            "name": "Java",
-                            "frameworks": [ 
-                                "Spring"
-                            ],
-                            "tools": [
-                                "Maven"
-                            ]
-                        }
-                    ]
-                }
-            ]
-        },
-        "https://github.com/nodeshift-starters/nodejs-configmap.git": {
-            "commit": "9710d7a74d995de3322e378d43528706c5d5f085",
-            "components": [
-                {
-                    "name": "nodejs-configmap",
-                    "languages": [
-                        {
-                            "name": "JavaScript",
-                            "frameworks": [ 
-                                "Express"
-                            ],
-                            "tools": [
-                                "NodeJs",
-                                "Node.js"
-                            ]
-                        }
-                    ]
-                }
-            ]
-        },
-        "https://github.com/nodeshift-starters/nodejs-messaging-work-queue.git": {
-            "commit": "5b95d6fc6c004a205cb2e966a4f78da736dfb44e",
-            "components": [
-                {
-                    "name": "nodejs-messaging-work-queue-frontend",
-                    "languages": [
-                        {
-                            "name": "JavaScript",
-                            "frameworks": [ 
-                                "Express"
-                            ],
-                            "tools": [
-                                "NodeJs",
-                                "Node.js"
-                            ]
-                        }
-                    ]
-                },
-                {
-                    "name": "nodejs-messaging-work-queue-worker",
-                    "languages": [
-                        {
-                            "name": "JavaScript",
-                            "frameworks": [ 
-                                "Express"
-                            ],
-                            "tools": [
-                                "NodeJs",
-                                "Node.js"
-                            ]
-                        }
-                    ]
-                }
-            ]
-        },
-        "https://github.com/nodeshift-starters/nodejs-cache.git": {
-            "commit": "8059b4520e07d3ffaec5c3759b918d86c8b574de",
-            "components": [
-                {
-                    "name": "nodejs-cache-cute-name",
-                    "languages": [
-                        {
-                            "name": "JavaScript",
-                            "frameworks": [ 
-                                "Express"
-                            ],
-                            "tools": [
-                                "NodeJs",
-                                "Node.js"
-                            ]
-                        }
-                    ]
-                },
-                {
-                    "name": "nodejs-cache-greeting",
-                    "languages": [
-                        {
-                            "name": "JavaScript",
-                            "frameworks": [ 
-                                "Express"
-                            ],
-                            "tools": [
-                                "NodeJs",
-                                "Node.js"
-                            ]
-                        }
-                    ]
-                }
-            ]
-        }
+        ]
+    },
+    "https://github.com/bezkoder/spring-boot-data-jpa-mysql.git": {
+        "commit": "75d0e3b13635a9a7a5e5a1c6b02c04366476227a",
+        "components": [
+            {
+                "name": "spring-boot-data-jpa",
+                "languages": [
+                    {
+                        "name": "Java",
+                        "frameworks": [
+                            "Spring"
+                        ],
+                        "tools": [
+                            "Maven"
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    "https://github.com/kylebuch8/urgent-care-finder-v2.git": {
+        "commit": "c9a32ce6f53bec3b915991bb4fe95ffd7bce8e2b",
+        "components": [
+            {
+                "name": "nextjs",
+                "languages": [
+                    {
+                        "name": "JavaScript",
+                        "frameworks": [
+                            "Next",
+                            "Next.js",
+                            "React"
+                        ],
+                        "tools": [
+                            "NodeJs",
+                            "Node.js"
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    "https://github.com/rh-aiservices-bu/object-detection-rest.git": {
+        "commit": "cd9b8b573518c3080e3ce60f61255b9e9e164f6e",
+        "components": [
+            {
+                "name": "ignore",
+                "languages": [
+                    {
+                        "name": "Python",
+                        "frameworks": [],
+                        "tools": []
+                    }
+                ]
+            }
+        ]
+    },
+    "https://github.com/gothinkster/spring-boot-realworld-example-app.git": {
+        "commit": "ee17e31aafe733d98c4853c8b9a74d7f2f6c924a",
+        "components": [
+            {
+                "name": "ignore",
+                "languages": [
+                    {
+                        "name": "Java",
+                        "frameworks": [
+                            "Spring"
+                        ],
+                        "tools": [
+                            "Gradle"
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    "https://github.com/spring-guides/gs-batch-processing.git": {
+        "commit": "19b0881fe060f15553d50aaef18a372735f2253d",
+        "components": [
+            {
+                "name": "batch-processing-complete",
+                "languages": [
+                    {
+                        "name": "Java",
+                        "frameworks": [
+                            "Spring"
+                        ],
+                        "tools": [
+                            "Gradle"
+                        ]
+                    }
+                ]
+            },
+            {
+                "name": "batch-processing-initial",
+                "languages": [
+                    {
+                        "name": "Java",
+                        "frameworks": [
+                            "Spring"
+                        ],
+                        "tools": [
+                            "Gradle"
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    "https://github.com/patternfly/patternfly-react-seed.git": {
+        "commit": "62e92b78a64c93f3fa8c059e7482aaa3192e681d",
+        "components": [
+            {
+                "name": "patternfly-seed",
+                "languages": [
+                    {
+                        "name": "TypeScript",
+                        "frameworks": [
+                            "React"
+                        ],
+                        "tools": [
+                            "NodeJs",
+                            "Node.js"
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    "https://github.com/bucharest-gold/s2i-nodejs.git": {
+        "commit": "c7f990e02a14560b756187dd8ad21d6eb74246d9",
+        "components": [
+            {
+                "name": "s2i-nodejs",
+                "languages": [
+                    {
+                        "name": "JavaScript",
+                        "frameworks": [ ],
+                        "tools": [
+                            "NodeJs",
+                            "Node.js"
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    "https://github.com/nodeshift-starters/opossum-examples.git": {
+        "commit": "821451be248a78dbd58a21f2f2e661ab332bf7ed",
+        "components": [
+            {
+                "name": "angular",
+                "languages": [
+                    {
+                        "name": "TypeScript",
+                        "frameworks": [
+                            "Angular"
+                        ],
+                        "tools": [
+                            "NodeJs",
+                            "Node.js"
+                        ]
+                    }
+                ]
+            },
+            {
+                "name": "opossum-angular",
+                "languages": [
+                    {
+                        "name": "TypeScript",
+                        "frameworks": [
+                            "Express"
+                        ],
+                        "tools": [
+                            "NodeJs",
+                            "Node.js"
+                        ]
+                    }
+                ],
+                "ports": [
+                    3000
+                ]
+            },
+            {
+                "name": "ember-opossum",
+                "languages": [
+                    {
+                        "name": "JavaScript",
+                        "frameworks": [ ],
+                        "tools": [
+                            "NodeJs",
+                            "Node.js"
+                        ]
+                    }
+                ]
+            },
+            {
+                "name": "ember-opossum",
+                "languages": [
+                    {
+                        "name": "JavaScript",
+                        "frameworks": [ ],
+                        "tools": [
+                            "NodeJs",
+                            "Node.js"
+                        ]
+                    }
+                ]
+            },
+            {
+                "name": "opossum-browser-example",
+                "languages": [
+                    {
+                        "name": "JavaScript",
+                        "frameworks": [ ],
+                        "tools": [
+                            "NodeJs",
+                            "Node.js"
+                        ]
+                    }
+                ]
+            },
+            {
+                "name": "database-timeout",
+                "languages": [
+                    {
+                        "name": "JavaScript",
+                        "frameworks": [
+                            "Express"
+                        ],
+                        "tools": [
+                            "NodeJs",
+                            "Node.js"
+                        ]
+                    }
+                ],
+                "ports": [
+                    3000
+                ]
+            },
+            {
+                "name": "multiple-express",
+                "languages": [
+                    {
+                        "name": "JavaScript",
+                        "frameworks": [
+                            "Express"
+                        ],
+                        "tools": [
+                            "NodeJs",
+                            "Node.js"
+                        ]
+                    }
+                ],
+                "ports": [
+                    8080
+                ]
+            },
+            {
+                "name": "typescript-example",
+                "languages": [
+                    {
+                        "name": "TypeScript",
+                        "frameworks": [ ],
+                        "tools": [
+                            "NodeJs",
+                            "Node.js"
+                        ]
+                    }
+                ]
+            },
+            {
+                "name": "express-prometheus-minishift",
+                "languages": [
+                    {
+                        "name": "JavaScript",
+                        "frameworks": [
+                            "Express"
+                        ],
+                        "tools": [
+                            "NodeJs",
+                            "Node.js"
+                        ]
+                    }
+                ]
+            },
+            {
+                "name": "opossum-react-client",
+                "languages": [
+                    {
+                        "name": "JavaScript",
+                        "frameworks": [
+                            "React"
+                        ],
+                        "tools": [
+                            "NodeJs",
+                            "Node.js"
+                        ]
+                    }
+                ],
+                "ports": [
+                    8000
+                ]
+            },
+            {
+                "name": "opossum-react",
+                "languages": [
+                    {
+                        "name": "JavaScript",
+                        "frameworks": [
+                            "Express"
+                        ],
+                        "tools": [
+                            "NodeJs",
+                            "Node.js"
+                        ]
+                    }
+                ],
+                "ports": [
+                    3000
+                ]
+            },
+            {
+                "name": "opossum-browser-example",
+                "languages": [
+                    {
+                        "name": "JavaScript",
+                        "frameworks": [ ],
+                        "tools": [
+                            "NodeJs",
+                            "Node.js"
+                        ]
+                    }
+                ]
+            },
+            {
+                "name": "svelte-app",
+                "languages": [
+                    {
+                        "name": "JavaScript",
+                        "frameworks": [ 
+                            "Svelte"
+                        ],
+                        "tools": [
+                            "NodeJs",
+                            "Node.js"
+                        ]
+                    }
+                ]
+            },
+            {
+                "name": "opossum-svelte",
+                "languages": [
+                    {
+                        "name": "JavaScript",
+                        "frameworks": [ 
+                            "Express"
+                        ],
+                        "tools": [
+                            "NodeJs",
+                            "Node.js"
+                        ]
+                    }
+                ],
+                "ports": [
+                    3000
+                ]
+            },
+            {
+                "name": "opossum-vue-client",
+                "languages": [
+                    {
+                        "name": "JavaScript",
+                        "frameworks": [ 
+                            "Vue"
+                        ],
+                        "tools": [
+                            "NodeJs",
+                            "Node.js"
+                        ]
+                    }
+                ]
+            },
+            {
+                "name": "opossum-vue",
+                "languages": [
+                    {
+                        "name": "JavaScript",
+                        "frameworks": [ 
+                            "Express"
+                        ],
+                        "tools": [
+                            "NodeJs",
+                            "Node.js"
+                        ]
+                    }
+                ],
+                "ports": [
+                    3000
+                ]
+            }
+        ]
+    },
+    "https://github.com/nodeshift-starters/nodejs-rest-http.git": {
+        "commit": "7b16266ce25bf4392c8f9a3a13f8fff76890ed05",
+        "components": [
+            {
+                "name": "nodejs-rest-http",
+                "languages": [
+                    {
+                        "name": "JavaScript",
+                        "frameworks": [ 
+                            "Express"
+                        ],
+                        "tools": [
+                            "NodeJs",
+                            "Node.js"
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    "https://github.com/nodeshift-starters/nodejs-circuit-breaker.git": {
+        "commit": "1879d4d716487890ecb6f98bf50aa44b8cc6f4c8",
+        "components": [
+            {
+                "name": "nodejs-circuit-breaker-greeting",
+                "languages": [
+                    {
+                        "name": "JavaScript",
+                        "frameworks": [ 
+                            "Express"
+                        ],
+                        "tools": [
+                            "NodeJs",
+                            "Node.js"
+                        ]
+                    }
+                ]
+            },
+            {
+                "name": "nodejs-circuit-breaker-name",
+                "languages": [
+                    {
+                        "name": "JavaScript",
+                        "frameworks": [ 
+                            "Express"
+                        ],
+                        "tools": [
+                            "NodeJs",
+                            "Node.js"
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    "https://github.com/nodeshift-starters/reactive-example.git": {
+        "commit": "86d452aaa1170a710b33227965b0828f6c5d78af",
+        "components": [
+            {
+                "name": "consumer-backend",
+                "languages": [
+                    {
+                        "name": "JavaScript",
+                        "frameworks": [ 
+                            "Express"
+                        ],
+                        "tools": [
+                            "NodeJs",
+                            "Node.js"
+                        ]
+                    }
+                ]
+            },
+            {
+                "name": "frontend",
+                "languages": [
+                    {
+                        "name": "JavaScript",
+                        "frameworks": [ 
+                            "Express"
+                        ],
+                        "tools": [
+                            "NodeJs",
+                            "Node.js"
+                        ]
+                    }
+                ]
+            },
+            {
+                "name": "producer-backend",
+                "languages": [
+                    {
+                        "name": "JavaScript",
+                        "frameworks": [ ],
+                        "tools": [
+                            "NodeJs",
+                            "Node.js"
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    "https://github.com/nodeshift-starters/nodejs-health-check.git": {
+        "commit": "8748b233c56b0f85a6a5e9a66a1caa60fb8cb3d1",
+        "components": [
+            {
+                "name": "nodejs-health-check",
+                "languages": [
+                    {
+                        "name": "JavaScript",
+                        "frameworks": [ 
+                            "Express"
+                        ],
+                        "tools": [
+                            "NodeJs",
+                            "Node.js"
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    "https://github.com/burrsutter/todo-apps.git": {
+        "commit": "9d03c47a15f9e4a651eac20b48cd8c6143d34815",
+        "directory": "quarkus-todo",
+        "components": [
+            {
+                "name": "quarkus-todo",
+                "languages": [
+                    {
+                        "name": "Java",
+                        "frameworks": [ 
+                            "Quarkus"
+                        ],
+                        "tools": [
+                            "Maven"
+                        ]
+                    }
+                ]
+            },
+            {
+                "name": "resources",
+                "languages": [
+                    {
+                        "name": "JavaScript",
+                        "frameworks": [ 
+                            "Vue"
+                        ],
+                        "tools": [
+                            "NodeJs",
+                            "Node.js"
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    "https://github.com/marcnuri-demo/jkube-remote-dev.git": {
+        "commit": "c56bb2124732180a5c5cc37217d1a07cd4119e4c",
+        "components": [
+            {
+                "name": "mail",
+                "languages": [
+                    {
+                        "name": "Java",
+                        "frameworks": [ 
+                            "Micronaut"
+                        ],
+                        "tools": [
+                            "Maven"
+                        ]
+                    }
+                ]
+            },
+            {
+                "name": "northwind",
+                "languages": [
+                    {
+                        "name": "Java",
+                        "frameworks": [ 
+                            "Quarkus"
+                        ],
+                        "tools": [
+                            "Maven"
+                        ]
+                    }
+                ]
+            },
+            {
+                "name": "order-faker",
+                "languages": [
+                    {
+                        "name": "Java",
+                        "frameworks": [ 
+                            "Spring"
+                        ],
+                        "tools": [
+                            "Maven"
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    "https://github.com/nodeshift-starters/nodejs-configmap.git": {
+        "commit": "9710d7a74d995de3322e378d43528706c5d5f085",
+        "components": [
+            {
+                "name": "nodejs-configmap",
+                "languages": [
+                    {
+                        "name": "JavaScript",
+                        "frameworks": [ 
+                            "Express"
+                        ],
+                        "tools": [
+                            "NodeJs",
+                            "Node.js"
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    "https://github.com/nodeshift-starters/nodejs-messaging-work-queue.git": {
+        "commit": "5b95d6fc6c004a205cb2e966a4f78da736dfb44e",
+        "components": [
+            {
+                "name": "nodejs-messaging-work-queue-frontend",
+                "languages": [
+                    {
+                        "name": "JavaScript",
+                        "frameworks": [ 
+                            "Express"
+                        ],
+                        "tools": [
+                            "NodeJs",
+                            "Node.js"
+                        ]
+                    }
+                ]
+            },
+            {
+                "name": "nodejs-messaging-work-queue-worker",
+                "languages": [
+                    {
+                        "name": "JavaScript",
+                        "frameworks": [ 
+                            "Express"
+                        ],
+                        "tools": [
+                            "NodeJs",
+                            "Node.js"
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    "https://github.com/nodeshift-starters/nodejs-cache.git": {
+        "commit": "8059b4520e07d3ffaec5c3759b918d86c8b574de",
+        "components": [
+            {
+                "name": "nodejs-cache-cute-name",
+                "languages": [
+                    {
+                        "name": "JavaScript",
+                        "frameworks": [ 
+                            "Express"
+                        ],
+                        "tools": [
+                            "NodeJs",
+                            "Node.js"
+                        ]
+                    }
+                ]
+            },
+            {
+                "name": "nodejs-cache-greeting",
+                "languages": [
+                    {
+                        "name": "JavaScript",
+                        "frameworks": [ 
+                            "Express"
+                        ],
+                        "tools": [
+                            "NodeJs",
+                            "Node.js"
+                        ]
+                    }
+                ]
+            }
+        ]
     }
 }

--- a/go/test/git_test.json
+++ b/go/test/git_test.json
@@ -607,6 +607,78 @@
                     ]
                 }
             ]
+        },
+        "https://github.com/gothinkster/spring-boot-realworld-example-app.git": {
+            "commit": "ee17e31aafe733d98c4853c8b9a74d7f2f6c924a",
+            "components": [
+                {
+                    "name": "spring-boot-realworld-example-app",
+                    "languages": [
+                        {
+                            "name": "Java",
+                            "frameworks": [
+                                "Spring"
+                            ],
+                            "tools": [
+                                "Gradle"
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        "https://github.com/spring-guides/gs-batch-processing.git": {
+            "commit": "19b0881fe060f15553d50aaef18a372735f2253d",
+            "components": [
+                {
+                    "name": "batch-processing-complete",
+                    "languages": [
+                        {
+                            "name": "Java",
+                            "frameworks": [
+                                "Spring"
+                            ],
+                            "tools": [
+                                "Gradle"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "batch-processing-initial",
+                    "languages": [
+                        {
+                            "name": "Java",
+                            "frameworks": [
+                                "Spring"
+                            ],
+                            "tools": [
+                                "Gradle"
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        "https://github.com/patternfly/patternfly-react-seed.git": {
+            "commit": "62e92b78a64c93f3fa8c059e7482aaa3192e681d",
+            "components": [
+                {
+                    "name": "patternfly-seed",
+                    "languages": [
+                        {
+                            "name": "TypeScript",
+                            "frameworks": [
+                                "React"
+                            ],
+                            "tools": [
+                                "NodeJs",
+                                "Node.js"
+                            ]
+                        }
+                    ]
+                }
+            ]
         }
     }
 }

--- a/go/test/git_test.json
+++ b/go/test/git_test.json
@@ -551,6 +551,62 @@
                     "15002"
                 ]
             }
-        ]
+        ],
+        "https://github.com/bezkoder/spring-boot-data-jpa-mysql.git": {
+            "commit": "75d0e3b13635a9a7a5e5a1c6b02c04366476227a",
+            "components": [
+                {
+                    "name": "spring-boot-data-jpa",
+                    "languages": [
+                        {
+                            "name": "Java",
+                            "frameworks": [
+                                "Spring"
+                            ],
+                            "tools": [
+                                "Maven"
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        "https://github.com/kylebuch8/urgent-care-finder-v2.git": {
+            "commit": "c9a32ce6f53bec3b915991bb4fe95ffd7bce8e2b",
+            "components": [
+                {
+                    "name": "nextjs",
+                    "languages": [
+                        {
+                            "name": "JavaScript",
+                            "frameworks": [
+                                "Next",
+                                "Next.js",
+                                "React"
+                            ],
+                            "tools": [
+                                "NodeJs",
+                                "Node.js"
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        "https://github.com/rh-aiservices-bu/object-detection-rest.git": {
+            "commit": "cd9b8b573518c3080e3ce60f61255b9e9e164f6e",
+            "components": [
+                {
+                    "name": "object-detection-rest",
+                    "languages": [
+                        {
+                            "name": "Python",
+                            "frameworks": [],
+                            "tools": []
+                        }
+                    ]
+                }
+            ]
+        }
     }
 }

--- a/go/test/git_test.json
+++ b/go/test/git_test.json
@@ -1043,6 +1043,108 @@
                     ]
                 }
             ]
+        },
+        "https://github.com/nodeshift-starters/nodejs-health-check.git": {
+            "commit": "8748b233c56b0f85a6a5e9a66a1caa60fb8cb3d1",
+            "components": [
+                {
+                    "name": "nodejs-health-check",
+                    "languages": [
+                        {
+                            "name": "JavaScript",
+                            "frameworks": [ 
+                                "Express"
+                            ],
+                            "tools": [
+                                "NodeJs",
+                                "Node.js"
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        "https://github.com/burrsutter/todo-apps.git": {
+            "commit": "9d03c47a15f9e4a651eac20b48cd8c6143d34815",
+            "directory": "quarkus-todo",
+            "components": [
+                {
+                    "name": "quarkus-todo",
+                    "languages": [
+                        {
+                            "name": "Java",
+                            "frameworks": [ 
+                                "Quarkus"
+                            ],
+                            "tools": [
+                                "Maven"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "resources",
+                    "languages": [
+                        {
+                            "name": "JavaScript",
+                            "frameworks": [ 
+                                "Vue"
+                            ],
+                            "tools": [
+                                "NodeJs",
+                                "Node.js"
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        "https://github.com/marcnuri-demo/jkube-remote-dev.git": {
+            "commit": "c56bb2124732180a5c5cc37217d1a07cd4119e4c",
+            "components": [
+                {
+                    "name": "mail",
+                    "languages": [
+                        {
+                            "name": "Java",
+                            "frameworks": [ 
+                                "Micronaut"
+                            ],
+                            "tools": [
+                                "Maven"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "northwind",
+                    "languages": [
+                        {
+                            "name": "Java",
+                            "frameworks": [ 
+                                "Quarkus"
+                            ],
+                            "tools": [
+                                "Maven"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "order-faker",
+                    "languages": [
+                        {
+                            "name": "Java",
+                            "frameworks": [ 
+                                "Spring"
+                            ],
+                            "tools": [
+                                "Maven"
+                            ]
+                        }
+                    ]
+                }
+            ]
         }
     }
 }


### PR DESCRIPTION
Repos added:

[https://github.com/JoranBergfeld/webshop.git](https://github.com/JoranBergfeld/webshop.git)
[https://github.com/bezkoder/spring-boot-data-jpa-mysql.git](https://github.com/bezkoder/spring-boot-data-jpa-mysql.git)
[https://github.com/kylebuch8/urgent-care-finder-v2.git](https://github.com/kylebuch8/urgent-care-finder-v2.git)
[https://github.com/rh-aiservices-bu/object-detection-rest.git](https://github.com/rh-aiservices-bu/object-detection-rest.git)
[https://github.com/gothinkster/spring-boot-realworld-example-app](https://github.com/gothinkster/spring-boot-realworld-example-app)
[https://github.com/spring-guides/gs-batch-processing](https://github.com/spring-guides/gs-batch-processing) -> it contains both maven and gradle config file. Gradle is the one that always win and the default chosen when those two are detected at the same time. In this case both config are used as it's an example repo and they leave the choice to the final user 
```
Choose either Gradle or Maven and the language you want to use. This guide assumes that you chose Java.
```
[https://github.com/patternfly/patternfly-react-seed.git](https://github.com/patternfly/patternfly-react-seed.git)
[https://github.com/nodeshift-starters/opossum-examples](https://github.com/nodeshift-starters/opossum-examples)
[https://github.com/nodeshift-starters/nodejs-rest-http](https://github.com/nodeshift-starters/nodejs-rest-http)
[https://github.com/nodeshift-starters/nodejs-circuit-breaker](https://github.com/nodeshift-starters/nodejs-circuit-breaker)
[https://github.com/nodeshift-starters/reactive-example.git](https://github.com/nodeshift-starters/reactive-example.git)
[https://github.com/nodeshift-starters/nodejs-health-check.git](https://github.com/nodeshift-starters/nodejs-health-check.git)

[https://github.com/burrsutter/todo-apps.git](https://github.com/burrsutter/todo-apps.git)
[https://github.com/marcnuri-demo/jkube-remote-dev](https://github.com/marcnuri-demo/jkube-remote-dev)
[https://github.com/nodeshift-starters/nodejs-configmap.git](https://github.com/nodeshift-starters/nodejs-configmap.git)
[https://github.com/nodeshift-starters/nodejs-messaging-work-queue.git](https://github.com/nodeshift-starters/nodejs-messaging-work-queue.git)
[https://github.com/nodeshift-starters/nodejs-cache.git](https://github.com/nodeshift-starters/nodejs-cache.git)


**Additional thoughts**

1. There are some repos that contains content related to data science projects that contain 90+% of jupyter notebook files and the rest are python so alizer's outcome will always be a python component. Does it make sense? Or would you expect something different?
E.g 
- [https://github.com/rh-aiservices-bu/metrobus-repairs-nlp-workshop](https://github.com/rh-aiservices-bu/metrobus-repairs-nlp-workshop)
-  [https://github.com/rh-aiservices-bu/intelligent-agriculture-demo](https://github.com/rh-aiservices-bu/intelligent-agriculture-demo)
-  [https://github.com/OpenShiftDemos/rhods-fraud-detection](https://github.com/OpenShiftDemos/rhods-fraud-detection)
- [https://github.com/rh-aiservices-bu/object-detection-kafka-consumer](https://github.com/rh-aiservices-bu/object-detection-kafka-consumer)

2. In many cases the port is not customized and the app runs on the default one (e.g on angular 4200, react 3000). Should alizer returns the default port if it does not detect anything? This could also lead to a false guess as the port could be customized in some way alizer does not know.