### PR TITLE
feat: add support for Containerfile

### DIFF
--- a/go/docs/port_detection.md
+++ b/go/docs/port_detection.md
@@ -5,7 +5,7 @@ Because of the different nature of frameworks supported, Alizer tries to use cus
 Only ports with value > 0 and < 65535 are valid.
 
 There are three detection strategies currently available:
-1) Docker file - Alizer looks for a Dockerfile in the root folder and tries to extract ports from it.
+1) Docker file - Alizer looks for a Dockerfile, or Containerfile, in the root folder and tries to extract ports from it.
 2) Compose file - Alizer searches for a docker-compose file in the root folder and tries to extract port of the service from it
 3) Source - If a framework has been detected during component detection, a customized detection is performed. Below a detailed overview of the different strategies for each supported framework.
 

--- a/go/pkg/apis/enricher/enricher.go
+++ b/go/pkg/apis/enricher/enricher.go
@@ -124,10 +124,13 @@ func GetDefaultProjectName(path string) string {
 }
 
 func GetPortsFromDockerFile(root string) []int {
-	file, err := os.Open(filepath.Join(root, "Dockerfile"))
-	if err == nil {
-		defer file.Close()
-		return getPortsFromReader(file)
+	locations := []string{"Dockerfile", "Containerfile"}
+	for _, location := range locations {
+		file, err := os.Open(filepath.Join(root, location))
+		if err == nil {
+			defer file.Close()
+			return getPortsFromReader(file)
+		}
 	}
 	return []int{}
 }

--- a/go/test/apis/component_recognizer_test.go
+++ b/go/test/apis/component_recognizer_test.go
@@ -209,6 +209,10 @@ func TestPortDetectionWithDockerFile(t *testing.T) {
 	testPortDetectionInProject(t, "projectDockerFile", []int{8085})
 }
 
+func TestPortDetectionWithContainerFile(t *testing.T) {
+	testPortDetectionInProject(t, "projectContainerFile", []int{8085})
+}
+
 func TestPortDetectionJavaMicronaut(t *testing.T) {
 	testPortDetectionInProject(t, "projectMicronaut", []int{4444})
 }

--- a/resources/projectPortTesting/projectContainerFile/Containerfile
+++ b/resources/projectPortTesting/projectContainerFile/Containerfile
@@ -1,0 +1,16 @@
+FROM node:16
+
+# Create app directory
+WORKDIR /usr/src/app
+
+# Install app dependencies
+# A wildcard is used to ensure both package.json AND package-lock.json are copied
+COPY package*.json ./
+
+RUN npm install
+
+# Bundle app source
+COPY . .
+
+EXPOSE 8085
+CMD [ "node", "server.js" ]

--- a/resources/projectPortTesting/projectContainerFile/package.json
+++ b/resources/projectPortTesting/projectContainerFile/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "nodejs-starter",
+  "version": "1.0.0",
+  "description": "Simple Node.js application",
+  "license": "EPL-2.0",
+  "scripts": {
+    "start": "node server.js",
+    "debug": "node --inspect-brk=${DEBUG_PORT} server.js",
+    "test": "node test/test.js"
+  },
+  "dependencies": {
+    "express": "^4.17.1",
+    "pino": "^6.2.1",
+    "pino-http": "^5.1.0",
+    "prom-client": "^12.0.0"
+  }
+}

--- a/resources/projectPortTesting/projectContainerFile/server.js
+++ b/resources/projectPortTesting/projectContainerFile/server.js
@@ -1,0 +1,21 @@
+const express = require('express');
+const http = require('http');
+
+const app = express();
+const server = http.createServer(app)
+
+app.get('/', (req, res) => {	
+  // Use req.log (a `pino` instance) to log JSON:	
+  req.log.info({message: 'Hello from my Node.js App!'});		
+  res.send('Hello from my Node.js App!');	
+});	
+
+app.get('*', (req, res) => {
+  res.status(404).send("Not Found");
+});
+
+// Listen and serve.
+const PORT = process.env.PORT || 3000;
+server.listen(PORT, () => {
+  console.log(`App started on PORT ${PORT}`);
+});


### PR DESCRIPTION
Containerfile is an alternate name for Dockerfile. They support the same syntax. See:
https://github.com/containers/common/blob/main/docs/Containerfile.5.md

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>