### PR TITLE
Use commit SHA instead of branch name for third-party actions

### DIFF
--- a/.github/workflows/checkLang.yml
+++ b/.github/workflows/checkLang.yml
@@ -12,12 +12,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2.3.4
-      - uses: GuillaumeFalourd/diff-action@v1
+        # v1
+      - uses: GuillaumeFalourd/diff-action@b341507d1da990caceac1b3b31b8f55eebaa2e99
         with:
           first_file_path: resources/languages.yml
           second_file_path: go/pkg/utils/langfiles/resources/languages.yml
           expected_result: PASSED
-      - uses: GuillaumeFalourd/diff-action@v1
+        # v1
+      - uses: GuillaumeFalourd/diff-action@b341507d1da990caceac1b3b31b8f55eebaa2e99
         with:
           first_file_path: resources/languages-customization.yml
           second_file_path: go/pkg/utils/langfiles/resources/languages-customization.yml


### PR DESCRIPTION
Hi!
Following the [GH Action Security Hardening](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) guide we should use the commit SHA instead of the `branch` or `tag` for any third-party untrusted action.