### PR TITLE
Create separate usage guides per implemenation and clean root readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,153 +6,39 @@
 ![Nightly][nightly-svg]
 
 ## Overview
+Alizer (which stands for Application Analyzer) is a utilily whose goal is to extract informations about an application source code.
+Such informations are:
 
-Alizer (which stands for Application Analyzer) is a utilily whose goal is to extract informations about an application source code. Such informations are:
+* Programming languages.
+* Frameworks.
+* Tools used to build the application.
 
-- source languages
-- frameworks used inside the application
-- tools used to build the application
+Additionaly, Alizer can also select one devfile (cloud workspace file) from a list of available devfiles and/or
+detect components (the concept of component is taken from Odo and its definition can be read on [odo.dev](https://odo.dev/docs/getting-started/basics/#component)).
 
-Also based on these informations, Alizer can also select one devfile (cloud workspace file) from a list of available devfiles 
-and/or detect components (the concept of component is taken from Odo and its definition can be read on [odo.dev](https://odo.dev/docs/getting-started/basics/#component)).
+In order to be easily intergrated in other projects, comes in 3 different implementations:
 
-Alizer comes in 4 different implementations:
+* Java library & CLI
+* Go library & CLI
+* NPM package
 
-- Java library
-- CLI
-- NPM package
-- Go library
-
-so that it can be integrated easily in other projects.
-
-NOTE: Not all implementations support the same features. Please check the table at [alizer-spec](https://github.com/redhat-developer/alizer/blob/main/docs/public/alizer-spec.md#feature-table) for a detailed overview.
+*NOTE: Not all implementations support the same features. Please check the table at [alizer-spec](docs/public/alizer-spec.md#feature-table) for a detailed overview.*
 
 ## Usage
+As mentioned above Alizer comes with 3 different implementations. Each one has a different usage guide:
 
-### Information
+* [Java library & CLI](java/README.md#Usage)
+* [Go library & CLI](go/README.md#Usage)
+* [NPM package](js/README.md#Usage)
 
-First, get access to the Alizer API through a LanguageRecognizer object which can be built like that:
-```java
-LanguageRecognizer recognizer = new RecognizerFactory().createLanguageRecognizer();
-```
-
-Then, access the project information with the `analyze` method:
-```java
-List<Language> languages = recognizer.analyze("myproject");
-```
-
-The result is an ordered list of information for each language detected in the source tree, with the following informations:
-- *name*: the name of the detected language
-- *framework*: a list of detected frameworks (Quarkus, Flash,...) used by the application
-- *tools*: a list of tools (Maven,...) used by the application
-- *weight*: a double value that represents the language weight compared to the others.
-
-NOTE: the sum of all weights can be over 100 because a file may be associated to multiple languages and Alizer may not be able to detect it precisely. E.g. a SQL script could be associated to SPLPL, TSQL, PLSQL languages so Alizer will return all 3 with the same weight.
-
-### Devfile selection
-
-It is also possible to select a devfile from a list of existing devfiles (from a devfile registry or other storage) based on the information that we can now extract from the source tree:
-```java
-DevfileType devfile = recognizer.selectDevFileFromTypes("myproject", devfiles)
-```
-where devfiles is a list of objects implementing the `DevfileType` interface which defines the following properties:
-- *name*: name of the devfile
-- *language*: name of the language associated with the devfile
-- *projectType*: type of project associated with the devfile
-- *tags*: list of tags associated with the devfile
-
-Please note that the devfile object that is returned by the method is one of the object from the list of devfiles given in input for better matching for the user.
-
-### Component detection
-
-Alizer is also able to detect components. The concept of component is taken from Odo and its definition can be read on [odo.dev](https://odo.dev/docs/getting-started/basics/#component).
-
-The detection of a component is based on only one rule. It is discovered if and only if the main language of the component source is one of those that supports component detection (Java, Python, Javascript, Go, ...)
-
-The result is a list of components where each component consists of:
-- *path*: root of the component 
-- *languages*: list of languages belonging to the component ordered by their relevance.
-
-```java
-ComponentRecognizer recognizer = new RecognizerFactory().createComponentRecognizer();
-List<Component> components = recognizer.analyze("myproject");
-```
-
-## CLI
-
-Alizer is also available through a CLI for applications that can't use the Java API.
-The syntax is the following:
-
-```
-alizer-cli-$version-runner analyze [-o json] <path>
-alizer-cli-$version-runner devfile [-o json] [-r registry-url] <path>
-```
-
-### NPM Package
-
-Alizer also offers a NPM package providing helpers for recognize languages/frameworks in a project. It still doesn't support devfile selection.
-The syntax is the following:
-
-```
-import * as recognizer from '@redhat-developer/alizer';
-
-.....
-
-const languages = await recognizer.detectLanguages('my_project_folder');
-
-.....
-
-```
-
-### Outputs 
-
-Quarkus project output example
-
-```
-[
-  { name: 'java', builder: 'maven', frameworks: [ 'quarkus' ] },
-  { name: 'gcc machine description' }
-]
-```
-
-SpringBoot project output example
-
-```
-[
-  { name: 'java', builder: 'maven', frameworks: [ 'springboot' ] },
-  { name: 'plsql' },
-  { name: 'plpgsql' },
-  { name: 'sqlpl' },
-  { name: 'tsql' },
-  { name: 'javascript' },
-  { name: 'batchfile' },
-  { name: 'gcc machine description' }
-]
-```
-
-Django project output example
-
-```
-[
-  { name: 'python', frameworks: [ 'django' ] },
-  { name: 'gcc machine description' },
-  { name: 'shell' }
-]
-```
-
-
-Contributing
-============
+## Contributing
 This is an open source project open to anyone. This project welcomes contributions and suggestions!
 
 For information on getting started, refer to the [CONTRIBUTING instructions](CONTRIBUTING.md).
 
-
-Feedback & Questions
-====================
+## Feedback & Questions
 If you discover an issue please file a bug and we will fix it as soon as possible.
 * File a bug in [GitHub Issues](https://github.com/redhat-developer/alizer/issues).
 
-License
-=======
+## License
 EPL 2.0, See [LICENSE](LICENSE) for more information.

--- a/README.md
+++ b/README.md
@@ -18,18 +18,18 @@ detect components (the concept of component is taken from Odo and its definition
 
 In order to be easily intergrated in other projects, comes in 3 different implementations:
 
-* Java library & CLI
 * Go library & CLI
-* NPM package
+* **[Deprecated]** Java library & CLI
+* **[Deprecated]** NPM package
 
 *NOTE: Not all implementations support the same features. Please check the table at [alizer-spec](docs/public/alizer-spec.md#feature-table) for a detailed overview.*
 
 ## Usage
 As mentioned above Alizer comes with 3 different implementations. Each one has a different usage guide:
 
-* [Java library & CLI](java/README.md#Usage)
 * [Go library & CLI](go/README.md#Usage)
-* [NPM package](js/README.md#Usage)
+* **[Deprecated]** [Java library & CLI](java/README.md#Usage)
+* **[Deprecated]** [NPM package](js/README.md#Usage)
 
 ## Contributing
 This is an open source project open to anyone. This project welcomes contributions and suggestions!

--- a/docs/public/alizer-spec.md
+++ b/docs/public/alizer-spec.md
@@ -6,28 +6,19 @@ This document outlines the features Alizer offers and how they actually work.
 
 Currently, Alizer provides 3 detection options:
 
-- Language Detection (Language/Tools/Frameworks)
-- DevFile Detection
-- Component Detection
+- *Language Detection* (Language/Tools/Frameworks)
+- *DevFile Detection*
+- *Component Detection*
 
-in 4 different implementations:
+in 3 different implementations:
 
-- Java library
-- CLI
-- NPM package
-- Go library
-
-so that it can be integrated easily in other projects.
-
-### Inner-loop scenario
-
-As a Vscode/IntelliJ plugin developer, I would like to detect the languages, tools, frameworks, services used within the
-opened user project in the IDE to provide a better user experience and tailor the functionalities I offer them.
+- Golang library & CLI.
+- **[Deprecated]**: Java library & CLI.
+- **[Deprecated]**: NPM package.
 
 ## Language Detection
 
-Language detection is based on the file `languages.yml` taken from the [GitHub's Linguist project](https://github.com/github/linguist/blob/master/lib/linguist/languages.yml).
-Because of that, Alizer is able to recognize almost any programming languages, with a customized deeper detection of the
+Language detection is based on the file `languages.yml` taken from the [GitHub's Linguist project](https://github.com/github/linguist/blob/master/lib/linguist/languages.yml). Because of that, Alizer is able to recognize almost any programming languages, with a customized deeper detection of the
 ones listed below:
 
 - Java
@@ -38,8 +29,7 @@ ones listed below:
 - GoLang
 
 Language recognition is performed by using files extensions within the source, and only the languages with a significant
-presence (>2% total files) are taken into account for further calculations.
-If any of languages above is detected, Alizer proceeds to check for the presence of tools and frameworks.
+presence (>2% total files) are taken into account for further calculations. If any of languages above is detected, Alizer proceeds to check for the presence of tools and frameworks.
 
 ### Java
 
@@ -167,9 +157,9 @@ a `language without a configuration file` in them. A simple Language detection i
 
 ## Feature table
 
-|                                  | Java API | CLI | Javascript | Go |
-|----------------------------------|----------|-----|------------|----|
-| Language/Framework detection     | X        | X   | X          | X  |
-| Devfile detection (metadata)     | X        | X   | X          | X  |
-| Devfile detection (registry URL) |          | X   |            |    |
-| Component detection              | X        | X   |            | X  |
+|                                  | Java API | Javascript | Go |
+|----------------------------------|----------|------------|----|
+| Language/Framework detection     | X        | X          | X  |
+| Devfile detection (metadata)     | X        | X          | X  |
+| Devfile detection (registry URL) |          |            | X  |
+| Component detection              | X        |            | X  |

--- a/go/README.md
+++ b/go/README.md
@@ -1,44 +1,62 @@
-# Alizer
-
-## Summary
-
-Alizer (which stands for Application Analyzer) is a utilily whose goal is to extract information about an application source code. 
-
-This folder includes the GoLang version of it.
-
-Alizer in Go extends three different detections:
-
-- Language Detection
-- Component Detection
-- Devfile Detection
+# Alizer - Go Library & CLI
 
 ## Usage
 
-### Language Detection
+### Library
+Below you can find usage information about the Go library.
 
-It allows to analyze the source code and extract informations about the languages, frameworks and tools used.
+#### Language Detection
+To analyze your source code with Alizer, just import it and use the recognizer:
+```go
+import "github.com/redhat-developer/alizer/pkg/apis/recognizer"
 
-The result is an ordered (sorted by usage) list of informations for each language detected in the source tree, with the following [data](https://github.com/redhat-developer/alizer/blob/main/go/pkg/apis/language/language.go#L13):
+languages, err := recognizer.Analyze("./")
+```
 
+The result is an ordered list *(sorted by usage)* of information for each language detected in the source tree, with the following [data](https://github.com/redhat-developer/alizer/blob/main/go/pkg/apis/language/language.go#L13):
 - *Name*: the name of the detected language
 - *Aliases*: other names which identify the detected language
 - *Framework*: a list of detected frameworks (Quarkus, Flash,...) used by the application
 - *Tools*: a list of tools (Maven,...) used by the application
 - *Weight*: a double value that represents the language weight compared to the others.
 
-NOTE: the sum of all weights can be over 100 because a file may be associated to multiple languages and Alizer may not be able to detect it precisely. E.g. a SQL script could be associated to SPLPL, TSQL, PLSQL so Alizer will print out all 3 languages with the same weight.
+*NOTE: the sum of all weights can be over 100 because a file may be associated to multiple languages and Alizer may not be able to detect it precisely. E.g. a SQL script could be associated to SPLPL, TSQL, PLSQL so Alizer will print out all 3 languages with the same weight.*
 
-To analyze your source code with Alizer, just import it and use the recognizer:
-
-```
+#### Devfile Detection
+It selects a devfile from a list of devfiles (from a devfile registry or other storage) based on the information found in the source tree. 
+```go
 import "github.com/redhat-developer/alizer/pkg/apis/recognizer"
 
-languages, err := recognizer.Analyze("./")
+devfile, err := recognizer.SelectDevFileFromTypes("myproject", devfiles)
 ```
 
-### Component Detection
+The response is a slice of `DevfileType` struct which contains the following named fields/properties:
+- *name*: name of the devfile
+- *language*: name of the language associated with the devfile
+- *projectType*: type of project associated with the devfile
+- *tags*: list of tags associated with the devfile
 
+Alizer searches for a component in the root folder and uses its information to select a devfile. If nothing is found in the root, a full components detection is performed and the first component in the resulting list is used to select a devfile. If no component is found in the whole source tree, a generic Language detection is run and the first language in the resulting list is used to select a devfile.
+
+*NOTE: The int value returned by the method is the position of the devfile selected by Alizer within the slice passed as parameter.*
+
+#### Component Detection
 It detects all components which are found in the source tree. The concept of component is taken from Odo and its definition can be read on [odo.dev](https://odo.dev/docs/overview/basics#component).
+```go
+import "github.com/redhat-developer/alizer/pkg/apis/recognizer"
+
+components, err := recognizer.DetectComponents("./")
+```
+
+The result is a list of components where each component consists of:
+- *name*: name of the component
+- *path*: root of the component 
+- *languages*: list of languages belonging to the component ordered by their relevance.
+- *ports*: list of ports used by the component
+
+Port detection is a long and consuming job and because of the different algorithms used for each different framework it deserves its own section. For more info check [port detection](docs/port_detection.md)
+
+For more info about name detection plase check the [name detection](docs/name_detection.md) doc.
 
 Component detection is only enabled for a subset of programming languages
 - Java
@@ -48,48 +66,86 @@ Component detection is only enabled for a subset of programming languages
 - Python
 - Rust
 
-and it consists of two steps:
+It consists of two steps:
 1) Detect languages which have a configuration file such as Java (`pom.xml`, `build.gradle`)
 2) Detect languages which may not have a configuration file such as Python
 
-Alizer scans all files in the source tree to find out a configuration file. If found and the language associated to it (e.g pom.xml -> JAVA) is enabled (belong to the list above) a component is said to be found starting from that path. This step gets repeated for all configuration files present in the source tree.
-
-To speed up the detection only the language associated to the configuration file is analyzed. If a configuration file can be associated to multiple languages (e.g. `.proj` can be part of either a C# or F# or VB.NET project) then a deep analysis is made.
+Alizer scans all files in the source tree to find out a configuration file. If found and the language associated to it (e.g pom.xml -> JAVA) is enabled (belong to the list above) a component is said to be found starting from that path. This step gets repeated for all configuration files present in the source tree. To speed up the detection only the language associated to the configuration file is analyzed. If a configuration file can be associated to multiple languages (e.g. `.proj` can be part of either a C# or F# or VB.NET project) then a deep analysis is made.
 
 Once the first step ends up, if there are no other free subfolders (free = folders that do not belong to any component) the second step is skipped otherwise Alizer tries to search for a component written with a language which may not have a configuration file. In that subfolder a simple Language detection is performed and the first language is taken into account for further calculations. 
 
-The result is a list of components where each component consists of:
-- *name*: name of the component
-- *path*: root of the component 
-- *languages*: list of languages belonging to the component ordered by their relevance.
-- *ports*: list of ports used by the component
+### CLI
+The Golang implementation includes CLI for applications.
 
-```
-import "github.com/redhat-developer/alizer/pkg/apis/recognizer"
-
-components, err := recognizer.DetectComponents("./")
+#### How to Build & Use
+The Go CLI can be built with the below command:
+```bash
+# inside the go/ dir
+$ go build alizer.go
 ```
 
-Port detection is a long and consuming job and because of the different algorithms used for each different framework it deserves its own section. For more info check [port detection](docs/port_detection.md)
-
-For more info about name detection plase check the [name detection](docs/name_detection.md) doc.
-
-### Devfile Detection
-
-It selects a devfile from a list of devfiles (from a devfile registry or other storage) based on the information found in the source tree. 
-
-Alizer searches for a component in the root folder and uses its information to select a devfile. If nothing is found in the root, a full components detection is performed and the first component in the resulting list is used to select a devfile. If no component is found in the whole source tree, a generic Language detection is run and the first language in the resulting list is used to select a devfile.
-
+In order to use the CLI:
 ```
-import "github.com/redhat-developer/alizer/pkg/apis/recognizer"
-
-devfile, err := recognizer.SelectDevFileFromTypes("myproject", devfiles)
+$ ./alizer analyze <path>
+$ ./alizer devfile <path>
 ```
 
-where devfiles is a slice of `DevfileType` struct which contains the following named fields/properties:
-- *name*: name of the devfile
-- *language*: name of the language associated with the devfile
-- *projectType*: type of project associated with the devfile
-- *tags*: list of tags associated with the devfile
+#### Outputs
+Example of `analyze` command:
+```json
+[
+	{
+		"Name": "Go",
+		"Aliases": [
+			"golang"
+		],
+		"Weight": 94.72,
+		"Frameworks": [],
+		"Tools": [
+			"1.18"
+		],
+		"CanBeComponent": true
+	}
+]
+```
 
-Please note that the int value returned by the method is the position of the devfile selected by Alizer within the slice passed as parameter.
+Example of `component` command:
+```json
+[
+    {
+		"Name": "spring4mvc-jpa",
+		"Path": "path-of-the-component",
+		"Languages": [
+			{
+				"Name": "Java",
+				"Aliases": null,
+				"Weight": 100,
+				"Frameworks": [
+					"Spring"
+				],
+				"Tools": [
+					"Maven"
+				],
+				"CanBeComponent": true
+			}
+		],
+		"Ports": null
+	},
+]
+```
+
+Example of `devfile` command:
+```json
+[
+	{
+		"Name": "nodejs",
+		"Language": "JavaScript",
+		"ProjectType": "Node.js",
+		"Tags": [
+			"Node.js",
+			"Express",
+			"ubi8"
+		]
+	}
+]
+```

--- a/go/docs/port_detection.md
+++ b/go/docs/port_detection.md
@@ -24,7 +24,7 @@ The port detection in a `[compose|docker-compose].[yml|yaml]` file targets the `
 To search for the specific component, Alizer look at the `build` field.
 
 Example of `expose` - the result is [3000,8000]
-```
+```yaml
 services:
   web:
     ...
@@ -39,7 +39,7 @@ services:
 ```
 
 Example of short syntax `ports` (`[HOST:]CONTAINER[/PROTOCOL]`) - the result is [3000,3005,8000,8081,8002,6060]
-```
+```yaml
 services:
   web:
     ...
@@ -56,7 +56,7 @@ services:
 ```
 
 Example of long syntax `ports` - the result is [6060]
-```
+```yaml
 services:
   web:
     ...
@@ -81,7 +81,7 @@ services:
 Alizer checks if the environment variable MICRONAUT_SERVER_SSL_ENABLED is set to true. If so, both MICRONAUT_SERVER_SSL_PORT and MICRONAUT_SERVER_PORT are checked (if false, only the MICRONAUT_SERVER_PORT is used for verification). If they are not set or they do not contain valid port values, Alizer searches for the `application.[yml|yaml]` file in `src/main/resources` folder and verify if one or more ports are set.
 
 The known schema is:
-```
+```yaml
 micronaut:
     server:
         port: <port>
@@ -95,7 +95,7 @@ micronaut:
 Alizer searches for the `server.xml` file within the root or `src/main/liberty/config` folder and verify if a port is set.
 
 The known schema is:
-```
+```xml
 <server>
     <httpEndpoint id="defaultHttpEndpoint"
         httpPort="<port>"
@@ -280,7 +280,7 @@ exports = {
 Alizer searches for the `default_port` property set within the `manage.py` file
 
 Example
-```
+```python
     import django
     django.setup()
 
@@ -313,7 +313,7 @@ Alizer searches either for 2 different function calls - `ListenAndServe(:<port>)
 If `<port>` is a variable, it tries to find its value within the code.
 
 Example
-```
+```go
 func main() {
   e := echo.New()
   // add middleware and routes

--- a/java/README.md
+++ b/java/README.md
@@ -1,7 +1,7 @@
 # Alizer - Java Library & CLI
 
 ## Usage
-
+*DEPRECATION WARNING: This implementation is out of date and it will be deprecated soon*
 ### Library
 Below you can find usage information about the Java library.
 

--- a/java/README.md
+++ b/java/README.md
@@ -1,0 +1,83 @@
+# Alizer - Java Library & CLI
+
+## Usage
+
+### Library
+Below you can find usage information about the Java library.
+
+#### Language Detection
+In order to access the Alizer Java API you will have to create a `LanguageRecognizer` object:
+```java
+LanguageRecognizer recognizer = new RecognizerFactory().createLanguageRecognizer();
+```
+
+Then, access the project information with the `analyze` method:
+```java
+List<Language> languages = recognizer.analyze("myproject");
+```
+
+The result is an ordered list of information for each language detected in the source tree, with the following informations:
+- *name*: the name of the detected language
+- *framework*: a list of detected frameworks (Quarkus, Flash,...) used by the application
+- *tools*: a list of tools (Maven,...) used by the application
+- *weight*: a double value that represents the language weight compared to the others.
+
+*NOTE: the sum of all weights can be over 100 because a file may be associated to multiple languages and Alizer may not be able to detect it precisely. E.g. a SQL script could be associated to SPLPL, TSQL, PLSQL languages so Alizer will return all 3 with the same weight.*
+
+#### Devfile Detection
+It is also possible to select a devfile from a list of existing devfiles (from a devfile registry or other storage) based on the information that we can now extract from the source tree:
+```java
+DevfileType devfile = recognizer.selectDevFileFromTypes("myproject", devfiles)
+```
+where devfiles is a list of objects implementing the `DevfileType` interface which defines the following properties:
+- *name*: name of the devfile
+- *language*: name of the language associated with the devfile
+- *projectType*: type of project associated with the devfile
+- *tags*: list of tags associated with the devfile
+
+Please note that the devfile object that is returned by the method is one of the object from the list of devfiles given in input for better matching for the user.
+
+#### Component detection
+Alizer is also able to detect components. The concept of component is taken from Odo and its definition can be read on [odo.dev](https://odo.dev/docs/getting-started/basics/#component).
+
+The detection of a component is based on only one rule. It is discovered if and only if the main language of the component source is one of those that supports component detection (Java, Python, Javascript, Go, ...)
+
+The result is a list of components where each component consists of:
+- *path*: root of the component 
+- *languages*: list of languages belonging to the component ordered by their relevance.
+
+```java
+ComponentRecognizer recognizer = new RecognizerFactory().createComponentRecognizer();
+List<Component> components = recognizer.analyze("myproject");
+```
+
+### CLI
+The Java implementation includes a CLI for applications.
+
+#### How to Build & Use
+The Java CLI can be built with the below command:
+```bash
+# inside the java/ dir
+$ ./mvnw package
+```
+
+In order to use the CLI:
+```
+# inside the java/alizer-cli/target dir
+alizer-cli-$version-runner analyze [-o json] <path>
+alizer-cli-$version-runner devfile [-o json] [-r registry-url] <path>
+```
+
+#### Outputs 
+
+Example of `analyze` command:
+```
+Language:JavaScript Frameworks:Express Tools:nodejs Accuracy:100.0
+```
+
+Example of `component` command:
+```
+Component:path/to/the/component1 Languages:JavaScript
+Component:path/to/the/component2 Languages:TypeScript,JavaScript
+Component:path/to/the/component3 Languages:TypeScript
+```

--- a/js/README.md
+++ b/js/README.md
@@ -1,6 +1,8 @@
 # Alizer - NPM Package
 
 ## Usage
+*DEPRECATION WARNING: This implementation is out of date and it will be deprecated soon*
+
 Alizer also offers a NPM package providing helpers for recognize languages/frameworks in a project. It still doesn't support devfile selection.
 The syntax is the following:
 ```js

--- a/js/README.md
+++ b/js/README.md
@@ -1,0 +1,44 @@
+# Alizer - NPM Package
+
+## Usage
+Alizer also offers a NPM package providing helpers for recognize languages/frameworks in a project. It still doesn't support devfile selection.
+The syntax is the following:
+```js
+import * as recognizer from '@redhat-developer/alizer';
+
+.....
+
+const languages = await recognizer.detectLanguages('my_project_folder');
+
+.....
+
+```
+The result is an ordered list of information for each language detected in the source tree, with the following informations:
+- *name*: the name of the detected language
+- *aliases*: other names which identify the detected language 
+- *builder*: tools that used to build the application
+- *frameworks*: a list of detected frameworks (Quarkus, Flash,...) used by the application.
+
+export interface DevfileType {
+    getName(): string;
+    getLanguage(): string;
+    getProjectType(): string;
+    getTags(): string[];
+}
+
+The NMP package 
+```js
+import * as recognizer from '@redhat-developer/alizer';
+
+.....
+
+const devfile = await recognizer.selectDevFileFromTypes('my_project_folder');
+
+.....
+
+```
+The result is an ordered list of information for each language detected in the source tree, with the following informations:
+- *name*: the name of the detected language.
+- *language*: name of the language associated with the devfile.
+- *projectType*: type of project associated with the devfile.
+- *tags*: list of tags associated with the devfile.


### PR DESCRIPTION
## What does this PR do?
This PR separates the usage guides and includes them inside each different implementation (Go, Java, JS).

### Which issue(s) does this PR fix
fixes https://github.com/redhat-developer/alizer/issues/149