### PR TITLE
Add Python configuration files to customization and Implement FlaskDetector

### DIFF
--- a/go/pkg/apis/enricher/framework/python/django_detector.go
+++ b/go/pkg/apis/enricher/framework/python/django_detector.go
@@ -29,14 +29,19 @@ func (d DjangoDetector) DoFrameworkDetection(language *model.Language, files *[]
 	urlsPy := utils.GetFile(files, "urls.py")
 	wsgiPy := utils.GetFile(files, "wsgi.py")
 	asgiPy := utils.GetFile(files, "asgi.py")
+	requirementsTxt := utils.GetFile(files, "requirements.txt")
+	projectToml := utils.GetFile(files, "project.toml")
 
 	djangoFiles := []string{}
+	configDjangoFiles := []string{}
 	utils.AddToArrayIfValueExist(&djangoFiles, managePy)
 	utils.AddToArrayIfValueExist(&djangoFiles, urlsPy)
 	utils.AddToArrayIfValueExist(&djangoFiles, wsgiPy)
 	utils.AddToArrayIfValueExist(&djangoFiles, asgiPy)
+	utils.AddToArrayIfValueExist(&configDjangoFiles, requirementsTxt)
+	utils.AddToArrayIfValueExist(&configDjangoFiles, projectToml)
 
-	if hasFramework(&djangoFiles, "from django.") {
+	if hasFramework(&djangoFiles, "from django.") || hasFramework(&configDjangoFiles, "django") || hasFramework(&configDjangoFiles, "Django") {
 		language.Frameworks = append(language.Frameworks, "Django")
 	}
 }

--- a/go/pkg/apis/enricher/framework/python/django_detector.go
+++ b/go/pkg/apis/enricher/framework/python/django_detector.go
@@ -30,7 +30,7 @@ func (d DjangoDetector) DoFrameworkDetection(language *model.Language, files *[]
 	wsgiPy := utils.GetFile(files, "wsgi.py")
 	asgiPy := utils.GetFile(files, "asgi.py")
 	requirementsTxt := utils.GetFile(files, "requirements.txt")
-	projectToml := utils.GetFile(files, "project.toml")
+	projectToml := utils.GetFile(files, "pyproject.toml")
 
 	djangoFiles := []string{}
 	configDjangoFiles := []string{}

--- a/go/pkg/apis/enricher/framework/python/flask_detector.go
+++ b/go/pkg/apis/enricher/framework/python/flask_detector.go
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc.
+ ******************************************************************************/
+package enricher
+
+import (
+	"context"
+
+	"github.com/redhat-developer/alizer/go/pkg/apis/model"
+	"github.com/redhat-developer/alizer/go/pkg/utils"
+)
+
+type FlaskDetector struct{}
+
+func (d FlaskDetector) GetSupportedFrameworks() []string {
+	return []string{"Flask"}
+}
+
+func (d FlaskDetector) DoFrameworkDetection(language *model.Language, files *[]string) {
+	appPy := utils.GetFile(files, "app.py")
+	initPy := utils.GetFile(files, "__init__.py")
+
+	djangoFiles := []string{}
+	utils.AddToArrayIfValueExist(&djangoFiles, appPy)
+	utils.AddToArrayIfValueExist(&djangoFiles, initPy)
+
+	if hasFramework(&djangoFiles, "from flask ") {
+		language.Frameworks = append(language.Frameworks, "Flask")
+	}
+}
+
+func (d FlaskDetector) DoPortsDetection(component *model.Component, ctx *context.Context) {
+	return
+}

--- a/go/pkg/apis/enricher/framework/python/flask_detector.go
+++ b/go/pkg/apis/enricher/framework/python/flask_detector.go
@@ -25,17 +25,22 @@ func (d FlaskDetector) GetSupportedFrameworks() []string {
 
 func (d FlaskDetector) DoFrameworkDetection(language *model.Language, files *[]string) {
 	appPy := utils.GetFile(files, "app.py")
-	initPy := utils.GetFile(files, "__init__.py")
+	wsgiPy := utils.GetFile(files, "wsgi.py")
+	requirementsTxt := utils.GetFile(files, "requirements.txt")
+	projectToml := utils.GetFile(files, "project.toml")
 
-	djangoFiles := []string{}
-	utils.AddToArrayIfValueExist(&djangoFiles, appPy)
-	utils.AddToArrayIfValueExist(&djangoFiles, initPy)
+	flaskFiles := []string{}
+	configFlaskFiles := []string{}
+	utils.AddToArrayIfValueExist(&flaskFiles, appPy)
+	utils.AddToArrayIfValueExist(&flaskFiles, wsgiPy)
+	utils.AddToArrayIfValueExist(&configFlaskFiles, requirementsTxt)
+	utils.AddToArrayIfValueExist(&configFlaskFiles, projectToml)
 
-	if hasFramework(&djangoFiles, "from flask ") {
+	if hasFramework(&flaskFiles, "from flask ") || hasFramework(&configFlaskFiles, "Flask") || hasFramework(&configFlaskFiles, "flask") {
 		language.Frameworks = append(language.Frameworks, "Flask")
 	}
 }
 
 func (d FlaskDetector) DoPortsDetection(component *model.Component, ctx *context.Context) {
-	return
+	// Not implemented yet
 }

--- a/go/pkg/apis/enricher/framework/python/flask_detector.go
+++ b/go/pkg/apis/enricher/framework/python/flask_detector.go
@@ -27,7 +27,7 @@ func (d FlaskDetector) DoFrameworkDetection(language *model.Language, files *[]s
 	appPy := utils.GetFile(files, "app.py")
 	wsgiPy := utils.GetFile(files, "wsgi.py")
 	requirementsTxt := utils.GetFile(files, "requirements.txt")
-	projectToml := utils.GetFile(files, "project.toml")
+	projectToml := utils.GetFile(files, "pyproject.toml")
 
 	flaskFiles := []string{}
 	configFlaskFiles := []string{}

--- a/go/pkg/apis/enricher/python_enricher.go
+++ b/go/pkg/apis/enricher/python_enricher.go
@@ -23,6 +23,7 @@ type PythonEnricher struct{}
 func getPythonFrameworkDetectors() []FrameworkDetectorWithoutConfigFile {
 	return []FrameworkDetectorWithoutConfigFile{
 		&framework.DjangoDetector{},
+		&framework.FlaskDetector{},
 	}
 }
 

--- a/go/pkg/utils/langfiles/resources/languages-customization.yml
+++ b/go/pkg/utils/langfiles/resources/languages-customization.yml
@@ -37,8 +37,6 @@ Python:
   configuration_files:
     - "manage.py"
     - "app.py"
-    - "config.py"
-    - "__init__.py"
   component: true
 Rust:
   configuration_files:

--- a/go/pkg/utils/langfiles/resources/languages-customization.yml
+++ b/go/pkg/utils/langfiles/resources/languages-customization.yml
@@ -35,8 +35,8 @@ JavaScript:
   component: true
 Python:
   configuration_files:
-    - "manage.py"
-    - "app.py"
+    - "requirements.txt"
+    - "project.toml"
   component: true
 Rust:
   configuration_files:

--- a/go/pkg/utils/langfiles/resources/languages-customization.yml
+++ b/go/pkg/utils/langfiles/resources/languages-customization.yml
@@ -34,6 +34,11 @@ JavaScript:
     - "[^-]package.json"
   component: true
 Python:
+  configuration_files:
+    - "manage.py"
+    - "app.py"
+    - "config.py"
+    - "__init__.py"
   component: true
 Rust:
   configuration_files:

--- a/go/pkg/utils/langfiles/resources/languages-customization.yml
+++ b/go/pkg/utils/langfiles/resources/languages-customization.yml
@@ -36,7 +36,7 @@ JavaScript:
 Python:
   configuration_files:
     - "requirements.txt"
-    - "project.toml"
+    - "pyproject.toml"
   component: true
 Rust:
   configuration_files:

--- a/go/test/git_test.json
+++ b/go/test/git_test.json
@@ -28,6 +28,7 @@
             }
         ]
     },
+
     "https://github.com/beego/beego-example.git": {
         "commit": "9729063b688570f8d472c4755744197c0bcd833d",
         "components": [
@@ -405,6 +406,23 @@
                         "name": "Python",
                         "frameworks": [
                             "Django"
+                        ],
+                        "tools": []
+                    }
+                ]
+            }
+        ]
+    },
+    "https://github.com/blues-man/pipelines-vote-ui.git": {
+        "commit": "bee52ea4620f210a1ea5f0b0633c316bedda959a",
+        "components": [
+            {
+                "name": "ignore",
+                "languages": [
+                    {
+                        "name": "Python",
+                        "frameworks": [
+                            "Flask"
                         ],
                         "tools": []
                     }

--- a/resources/languages-customization.yml
+++ b/resources/languages-customization.yml
@@ -37,8 +37,6 @@ Python:
   configuration_files:
     - "manage.py"
     - "app.py"
-    - "config.py"
-    - "__init__.py"
   component: true
 Rust:
   configuration_files:

--- a/resources/languages-customization.yml
+++ b/resources/languages-customization.yml
@@ -35,8 +35,8 @@ JavaScript:
   component: true
 Python:
   configuration_files:
-    - "manage.py"
-    - "app.py"
+    - "requirements.txt"
+    - "project.toml"
   component: true
 Rust:
   configuration_files:

--- a/resources/languages-customization.yml
+++ b/resources/languages-customization.yml
@@ -34,6 +34,11 @@ JavaScript:
     - "[^-]package.json"
   component: true
 Python:
+  configuration_files:
+    - "manage.py"
+    - "app.py"
+    - "config.py"
+    - "__init__.py"
   component: true
 Rust:
   configuration_files:

--- a/resources/languages-customization.yml
+++ b/resources/languages-customization.yml
@@ -36,7 +36,7 @@ JavaScript:
 Python:
   configuration_files:
     - "requirements.txt"
-    - "project.toml"
+    - "pyproject.toml"
   component: true
 Rust:
   configuration_files:


### PR DESCRIPTION
## What does this PR do?

It adds a list of `configuration_files` inside the `languages-customization.yaml` file:

```yaml
Python:
  configuration_files:
    - "pyproject.toml"
    - "requirements.txt"
  component: true
  ```
This allows the `component_recognizer` to be able to recognize `Python` components, from their `configuration_files`, in given projects.

It adds functionality to `DjangoDetector` in order to be able to recognize if a `Python` project has `django` as framework, through `requirements.txt` or `pyproject.toml` files.

It also creates the `FlaskDetector` which allows the `PythonEnricher` to recognize `flask` as framework of a `python` project.

## Which issue(s) this PR fixes:

fixes https://github.com/redhat-developer/alizer/issues/165