### PR TITLE
Add second tag for spring framework

### DIFF
--- a/go/pkg/apis/enricher/framework/java/spring_detector.go
+++ b/go/pkg/apis/enricher/framework/java/spring_detector.go
@@ -33,12 +33,12 @@ type ApplicationProsServer struct {
 }
 
 func (s SpringDetector) GetSupportedFrameworks() []string {
-	return []string{"Spring"}
+	return []string{"Spring", "Spring Boot"}
 }
 
 func (s SpringDetector) DoFrameworkDetection(language *model.Language, config string) {
 	if hasFwk, _ := hasFramework(config, "org.springframework"); hasFwk {
-		language.Frameworks = append(language.Frameworks, "Spring")
+		language.Frameworks = append(language.Frameworks, s.GetSupportedFrameworks()...)
 	}
 }
 


### PR DESCRIPTION
## What does this PR do?

Adds a second item inside the `SpringDetector.GetSupportedFrameworks` func. As a result, when the Spring Boot framework is identified inside a project, it adds two tags inside the `language.Frameworks`

```golang
func (s SpringDetector) GetSupportedFrameworks() []string {
	return []string{"Spring", "Spring Boot"}
}

func (s SpringDetector) DoFrameworkDetection(language *model.Language, config string) {
	if hasFwk, _ := hasFramework(config, "org.springframework"); hasFwk {
		language.Frameworks = append(language.Frameworks, s.GetSupportedFrameworks()...)
	}
}
```

Finally, it will be able to [match](https://github.com/redhat-developer/alizer/blob/8f7afff3b7cde384ca6ae640a6917d4a8060431b/go/pkg/apis/recognizer/devfile_recognizer.go#L152-L153) the given tag of "Spring Boot" whenever it is updated from the registry side. Note, that this solution is backwards compatible. Once the update of the "Spring" tag to "Spring Boot" is done, we can iterate and have only "Spring Boot" as supported network.

## Which issue(s) this PR fixes:

fixes https://github.com/redhat-developer/alizer/issues/136

## Test outputs
I've forced updated locally the tag "Spring" to "Spring Boot" and tested this solution:

```golang
// go/pkg/apis/recognizer/devfile_recognizer.go#L151
for _, tag := range devFile.Tags {
  if tag == "Spring" {
	  tag = "Spring Boot"
  }
  if frw := matches(language.Frameworks, tag); frw != "" {
	  frameworkPerDevfileTmp[frw] = nil
	  score += utils.FRAMEWORK_WEIGHT
  }
  if matches(language.Tools, tag) != "" {
	  score += utils.TOOL_WEIGHT
  }
}
```
And the output is:
```json
[
	{
		"Name": "java-springboot",
		"Language": "Java",
		"ProjectType": "springboot",
		"Tags": [
			"Java",
			"Spring"
		]
	}
]
```
