### PR TITLE
Add second-level dockerfile, containerfile search for Port recognition

### DIFF
--- a/go/test/apis/component_recognizer_test.go
+++ b/go/test/apis/component_recognizer_test.go
@@ -211,6 +211,14 @@ func TestPortDetectionWithContainerFile(t *testing.T) {
 	testPortDetectionInProject(t, "projectContainerFile", []int{8085})
 }
 
+func TestPortDetectionWithSecondLevelDockerFile(t *testing.T) {
+	testPortDetectionInProject(t, "projectNestedDockerFile", []int{8085})
+}
+
+func TestPortDetectionWithSecondLevelContainerFile(t *testing.T) {
+	testPortDetectionInProject(t, "projectNestedContainerFile", []int{8085})
+}
+
 func TestPortDetectionJavaMicronaut(t *testing.T) {
 	testPortDetectionInProject(t, "projectMicronaut", []int{4444})
 }

--- a/resources/projectPortTesting/projectNestedContainerFile/docker/Containerfile
+++ b/resources/projectPortTesting/projectNestedContainerFile/docker/Containerfile
@@ -1,0 +1,16 @@
+FROM node:16
+
+# Create app directory
+WORKDIR /usr/src/app
+
+# Install app dependencies
+# A wildcard is used to ensure both package.json AND package-lock.json are copied
+COPY package*.json ./
+
+RUN npm install
+
+# Bundle app source
+COPY . .
+
+EXPOSE 8085
+CMD [ "node", "server.js" ]

--- a/resources/projectPortTesting/projectNestedContainerFile/package.json
+++ b/resources/projectPortTesting/projectNestedContainerFile/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "nodejs-starter",
+  "version": "1.0.0",
+  "description": "Simple Node.js application",
+  "license": "EPL-2.0",
+  "scripts": {
+    "start": "node server.js",
+    "debug": "node --inspect-brk=${DEBUG_PORT} server.js",
+    "test": "node test/test.js"
+  },
+  "dependencies": {
+    "express": "^4.17.1",
+    "pino": "^6.2.1",
+    "pino-http": "^5.1.0",
+    "prom-client": "^12.0.0"
+  }
+}

--- a/resources/projectPortTesting/projectNestedContainerFile/server.js
+++ b/resources/projectPortTesting/projectNestedContainerFile/server.js
@@ -1,0 +1,21 @@
+const express = require('express');
+const http = require('http');
+
+const app = express();
+const server = http.createServer(app)
+
+app.get('/', (req, res) => {	
+  // Use req.log (a `pino` instance) to log JSON:	
+  req.log.info({message: 'Hello from my Node.js App!'});		
+  res.send('Hello from my Node.js App!');	
+});	
+
+app.get('*', (req, res) => {
+  res.status(404).send("Not Found");
+});
+
+// Listen and serve.
+const PORT = process.env.PORT || 3000;
+server.listen(PORT, () => {
+  console.log(`App started on PORT ${PORT}`);
+});

--- a/resources/projectPortTesting/projectNestedDockerFile/docker/Dockerfile
+++ b/resources/projectPortTesting/projectNestedDockerFile/docker/Dockerfile
@@ -1,0 +1,16 @@
+FROM node:16
+
+# Create app directory
+WORKDIR /usr/src/app
+
+# Install app dependencies
+# A wildcard is used to ensure both package.json AND package-lock.json are copied
+COPY package*.json ./
+
+RUN npm install
+
+# Bundle app source
+COPY . .
+
+EXPOSE 8085
+CMD [ "node", "server.js" ]

--- a/resources/projectPortTesting/projectNestedDockerFile/package.json
+++ b/resources/projectPortTesting/projectNestedDockerFile/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "nodejs-starter",
+  "version": "1.0.0",
+  "description": "Simple Node.js application",
+  "license": "EPL-2.0",
+  "scripts": {
+    "start": "node server.js",
+    "debug": "node --inspect-brk=${DEBUG_PORT} server.js",
+    "test": "node test/test.js"
+  },
+  "dependencies": {
+    "express": "^4.17.1",
+    "pino": "^6.2.1",
+    "pino-http": "^5.1.0",
+    "prom-client": "^12.0.0"
+  }
+}

--- a/resources/projectPortTesting/projectNestedDockerFile/server.js
+++ b/resources/projectPortTesting/projectNestedDockerFile/server.js
@@ -1,0 +1,21 @@
+const express = require('express');
+const http = require('http');
+
+const app = express();
+const server = http.createServer(app)
+
+app.get('/', (req, res) => {	
+  // Use req.log (a `pino` instance) to log JSON:	
+  req.log.info({message: 'Hello from my Node.js App!'});		
+  res.send('Hello from my Node.js App!');	
+});	
+
+app.get('*', (req, res) => {
+  res.status(404).send("Not Found");
+});
+
+// Listen and serve.
+const PORT = process.env.PORT || 3000;
+server.listen(PORT, () => {
+  console.log(`App started on PORT ${PORT}`);
+});


### PR DESCRIPTION
## What does this PR do?

Upon `enricher.GetPortsFromDockerFile()` it fetches all `locations` from the given `root` path. The main functionality is added with the `enricher.getLocations()` function:

```golang
func getLocations(root string) []string {
	locations := []string{"Dockerfile", "Containerfile"}
	dirItems, err := ioutil.ReadDir(root)
	if err != nil {
		return locations
	}
	for _, item := range dirItems {
		if strings.HasPrefix(item.Name(), ".") {
			continue
		}
		tmpPath := fmt.Sprintf("%s%s", root, item.Name())
		fileInfo, err := os.Stat(tmpPath)
		if err != nil {
			continue
		}
		if fileInfo.IsDir() {
			locations = append(locations, fmt.Sprintf("%s/%s", item.Name(), "Dockerfile"))
			locations = append(locations, fmt.Sprintf("%s/%s", item.Name(), "Containerfile"))
		}
	}
	return locations
}
```
More detailed, for each `item` it finds inside the given path, it checks if the `item` starts with `.` and if the `item` is a directory. In case it is it adds two different items in the `locations` list, one path with `containerfile` and a second one with `dockerfile`.

Finally, it adds two cases (again one for a nested/second-level dockerfile and one for a containerfile)

## Which issue(s) this PR fixes:

fixes https://github.com/redhat-developer/alizer/issues/152