### PR TITLE
Add udi image case for mocked values of devfile types

### DIFF
--- a/go/test/apis/devfile_recognizer_test.go
+++ b/go/test/apis/devfile_recognizer_test.go
@@ -151,6 +151,23 @@ func getDevFileTypes() []model.DevFileType {
 			Tags:        make([]string, 0),
 		},
 		{
+			Name:        "udi",
+			Language:    "Polyglot",
+			ProjectType: "default",
+			Tags: []string{
+				"Java",
+				"Maven",
+				"Scala",
+				"PHP",
+				".NET",
+				"Node.js",
+				"Go",
+				"Python",
+				"Pip",
+				"ubi8",
+			},
+		},
+		{
 			Name:        "java-quarkus",
 			Language:    "java",
 			ProjectType: "quarkus",


### PR DESCRIPTION
## What does this PR do?

Inside this [PR](https://github.com/devfile/registry/pull/177) we are introducing the universal image. The current PR is ensuring that we are always checking in our tests that there is no impact of this change (e.g. the universal image devfile is selected first instead of a more related one).

To do this PR adds a new mocked `model.devfileType` instance inside `tests.getDevFileTypes()`:
```golang
{
	Name:        "udi",
	Language:    "Polyglot",
	ProjectType: "default",
	Tags: []string{
		"Java",
		"Maven",
		"Scala",
		"PHP",
		".NET",
		"Node.js",
		"Go",
		"Python",
		"Pip",
		"ubi8",
	},
},
```

## Which issue(s) this PR fixes:

fixes https://github.com/redhat-developer/alizer/issues/174