### PR TITLE
Enhance go port recognition

### DIFF
--- a/go/pkg/apis/enricher/go_enricher.go
+++ b/go/pkg/apis/enricher/go_enricher.go
@@ -85,6 +85,9 @@ func (j GoEnricher) DoEnrichComponent(component *model.Component, settings model
 						}
 					}
 				}
+				if len(component.Ports) == 0 {
+					framework.DoGoPortsDetection(component, ctx)
+				}
 			}
 		}
 		if len(ports) > 0 {

--- a/go/test/apis/component_recognizer_test.go
+++ b/go/test/apis/component_recognizer_test.go
@@ -276,6 +276,10 @@ func TestPortDetectionGoGin(t *testing.T) {
 	testPortDetectionInProject(t, "projectGin", []int{8789})
 }
 
+func TestPortDetectionGo(t *testing.T) {
+	testPortDetectionInProject(t, "projectGo", []int{8080})
+}
+
 func TestPortDetectionGoFiber(t *testing.T) {
 	testPortDetectionInProject(t, "projectGoFiber", []int{3000})
 }

--- a/go/test/apis/devfile_recognizer_test.go
+++ b/go/test/apis/devfile_recognizer_test.go
@@ -151,6 +151,23 @@ func getDevFileTypes() []model.DevFileType {
 			Tags:        make([]string, 0),
 		},
 		{
+			Name:        "udi",
+			Language:    "Polyglot",
+			ProjectType: "default",
+			Tags: []string{
+				"Java",
+				"Maven",
+				"Scala",
+				"PHP",
+				".NET",
+				"Node.js",
+				"Go",
+				"Python",
+				"Pip",
+				"ubi8",
+			},
+		},
+		{
 			Name:        "java-quarkus",
 			Language:    "java",
 			ProjectType: "quarkus",

--- a/resources/projectPortTesting/projectGo/go.mod
+++ b/resources/projectPortTesting/projectGo/go.mod
@@ -1,0 +1,3 @@
+module github.com/burrsutter/go-net-http-hello
+
+go 1.19

--- a/resources/projectPortTesting/projectGo/main.go
+++ b/resources/projectPortTesting/projectGo/main.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+)
+
+func main() {
+
+	//api := mux.NewRouter()
+	http.HandleFunc("/", HelloHandler)
+	//http.Handle("/hello", api)
+
+	fmt.Println("Listening on localhost:8080")
+	http.ListenAndServe(":8080", nil)
+}
+
+func HelloHandler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	hostname, err := os.Hostname()
+	if err != nil {
+		fmt.Println("unable to get hostname")
+	}
+
+	// fmt.Fprintf(w, "Hello from Go! %s on %s\n", time.Now(), hostname)
+	fmt.Fprintf(w, "Go Hello on %s\n", hostname)
+}

--- a/resources/projectPortTesting/projectGo/main.go
+++ b/resources/projectPortTesting/projectGo/main.go
@@ -7,11 +7,7 @@ import (
 )
 
 func main() {
-
-	//api := mux.NewRouter()
 	http.HandleFunc("/", HelloHandler)
-	//http.Handle("/hello", api)
-
 	fmt.Println("Listening on localhost:8080")
 	http.ListenAndServe(":8080", nil)
 }
@@ -22,7 +18,5 @@ func HelloHandler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		fmt.Println("unable to get hostname")
 	}
-
-	// fmt.Fprintf(w, "Hello from Go! %s on %s\n", time.Now(), hostname)
 	fmt.Fprintf(w, "Go Hello on %s\n", hostname)
 }


### PR DESCRIPTION
## What does this PR do?

Implements an additional check for port recognition upon `go_enricher` checks. More detailed, inside the `GoEnricher.DoEnrichComponent` for `case: model.Source` if all checks inside `framework.***Detector.DoPortDetection` have not returned any ports, it runs the `framework.DoGoPortsDetection` in order to check if there are any ports specified inside the root folder of the project.

```golang
case model.Source:
	{
		for _, detector := range getGoFrameworkDetectors() {
			for _, framework := range component.Languages[0].Frameworks {
				if utils.Contains(detector.GetSupportedFrameworks(), framework) {
					detector.DoPortsDetection(component, ctx)
				}
			}
		}
		if len(component.Ports) == 0 {
			framework.DoGoPortsDetection(component, ctx)
		}
	}
}
```
The `framework.DoGoPortsDetection` uses the same functionality for source port recognition (like other framework detectors). Finally a test case for Go project recognition is added in the test cases, along with a test project.

## Which issue(s) this PR fixes:
This PR partially fixes: #146 	