### PR TITLE
Fix gosec warnings

### DIFF
--- a/go/pkg/apis/enricher/enricher.go
+++ b/go/pkg/apis/enricher/enricher.go
@@ -125,7 +125,8 @@ func GetDefaultProjectName(path string) string {
 func GetPortsFromDockerFile(root string) []int {
 	locations := getLocations(root)
 	for _, location := range locations {
-		file, err := os.Open(filepath.Join(root, location))
+		filePath := filepath.Join(root, filepath.Clean(location))
+		file, err := os.Open(filePath)
 		if err == nil {
 			defer file.Close()
 			return getPortsFromReader(file)

--- a/go/pkg/apis/enricher/enricher.go
+++ b/go/pkg/apis/enricher/enricher.go
@@ -128,7 +128,12 @@ func GetPortsFromDockerFile(root string) []int {
 		filePath := filepath.Join(root, filepath.Clean(location))
 		file, err := os.Open(filePath)
 		if err == nil {
-			defer file.Close()
+			defer func() error {
+				if err := file.Close(); err != nil {
+					return fmt.Errorf("error closing file: %s", err)
+				}
+				return nil
+			}()
 			return getPortsFromReader(file)
 		}
 	}

--- a/go/pkg/apis/enricher/enricher.go
+++ b/go/pkg/apis/enricher/enricher.go
@@ -125,8 +125,9 @@ func GetDefaultProjectName(path string) string {
 func GetPortsFromDockerFile(root string) []int {
 	locations := getLocations(root)
 	for _, location := range locations {
-		filePath := filepath.Join(root, filepath.Clean(location))
-		file, err := os.Open(filePath)
+		filePath := filepath.Join(root, location)
+		cleanFilePath := filepath.Clean(filePath)
+		file, err := os.Open(cleanFilePath)
 		if err == nil {
 			defer func() error {
 				if err := file.Close(); err != nil {

--- a/go/pkg/apis/enricher/framework/dotnet/dotnet_detector.go
+++ b/go/pkg/apis/enricher/framework/dotnet/dotnet_detector.go
@@ -14,6 +14,7 @@ package enricher
 import (
 	"context"
 	"encoding/xml"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -64,7 +65,12 @@ func getFrameworks(configFilePath string) string {
 	var proj schema.DotNetProject
 	xml.Unmarshal(byteValue, &proj)
 
-	defer xmlFile.Close()
+	defer func() error {
+		if err := xmlFile.Close(); err != nil {
+			return fmt.Errorf("error closing file: %s", err)
+		}
+		return nil
+	}()
 	if proj.PropertyGroup.TargetFramework != "" {
 		return proj.PropertyGroup.TargetFramework
 	} else if proj.PropertyGroup.TargetFrameworkVersion != "" {

--- a/go/pkg/apis/enricher/framework/dotnet/dotnet_detector.go
+++ b/go/pkg/apis/enricher/framework/dotnet/dotnet_detector.go
@@ -16,6 +16,7 @@ import (
 	"encoding/xml"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/redhat-developer/alizer/go/pkg/apis/model"
@@ -53,7 +54,8 @@ func (d DotNetDetector) DoPortsDetection(component *model.Component, ctx *contex
 }
 
 func getFrameworks(configFilePath string) string {
-	xmlFile, err := os.Open(configFilePath)
+	cleanConfigPath := filepath.Clean(configFilePath)
+	xmlFile, err := os.Open(cleanConfigPath)
 	if err != nil {
 		return ""
 	}

--- a/go/pkg/apis/enricher/framework/dotnet/dotnet_detector.go
+++ b/go/pkg/apis/enricher/framework/dotnet/dotnet_detector.go
@@ -63,8 +63,10 @@ func getFrameworks(configFilePath string) string {
 	byteValue, _ := ioutil.ReadAll(xmlFile)
 
 	var proj schema.DotNetProject
-	xml.Unmarshal(byteValue, &proj)
-
+	err = xml.Unmarshal(byteValue, &proj)
+	if err != nil {
+		return ""
+	}
 	defer func() error {
 		if err := xmlFile.Close(); err != nil {
 			return fmt.Errorf("error closing file: %s", err)

--- a/go/pkg/apis/enricher/framework/go/echo_detector.go
+++ b/go/pkg/apis/enricher/framework/go/echo_detector.go
@@ -13,7 +13,6 @@ package enricher
 
 import (
 	"context"
-	"os"
 	"regexp"
 
 	"github.com/redhat-developer/alizer/go/pkg/apis/model"
@@ -59,16 +58,8 @@ func (e EchoDetector) DoPortsDetection(component *model.Component, ctx *context.
 		},
 	}
 
-	for _, file := range files {
-		bytes, err := os.ReadFile(file)
-		if err != nil {
-			continue
-		}
-		ports := GetPortFromFileGo(matchRegexRules, string(bytes))
-		if len(ports) > 0 {
-			component.Ports = ports
-			return
-		}
+	ports := GetPortFromFilesGo(matchRegexRules, files)
+	if len(ports) > 0 {
+		component.Ports = ports
 	}
-
 }

--- a/go/pkg/apis/enricher/framework/go/fasthttp_detector.go
+++ b/go/pkg/apis/enricher/framework/go/fasthttp_detector.go
@@ -13,7 +13,6 @@ package enricher
 
 import (
 	"context"
-	"os"
 	"regexp"
 
 	"github.com/redhat-developer/alizer/go/pkg/apis/model"
@@ -40,7 +39,7 @@ func (f FastHttpDetector) DoPortsDetection(component *model.Component, ctx *cont
 		return
 	}
 
-	matchRegexRule := model.PortMatchRules{
+	matchRegexRules := model.PortMatchRules{
 		MatchIndexRegexes: []model.PortMatchRule{
 			{
 				Regex:     regexp.MustCompile(`.ListenAndServe\([^,)]*`),
@@ -48,16 +47,8 @@ func (f FastHttpDetector) DoPortsDetection(component *model.Component, ctx *cont
 			},
 		},
 	}
-	for _, file := range files {
-		bytes, err := os.ReadFile(file)
-		if err != nil {
-			continue
-		}
-		ports := GetPortFromFileGo(matchRegexRule, string(bytes))
-		if len(ports) > 0 {
-			component.Ports = ports
-			return
-		}
+	ports := GetPortFromFilesGo(matchRegexRules, files)
+	if len(ports) > 0 {
+		component.Ports = ports
 	}
-
 }

--- a/go/pkg/apis/enricher/framework/go/gin_detector.go
+++ b/go/pkg/apis/enricher/framework/go/gin_detector.go
@@ -13,7 +13,6 @@ package enricher
 
 import (
 	"context"
-	"os"
 	"regexp"
 
 	"github.com/redhat-developer/alizer/go/pkg/apis/model"
@@ -40,7 +39,7 @@ func (g GinDetector) DoPortsDetection(component *model.Component, ctx *context.C
 		return
 	}
 
-	matchRegexRule := model.PortMatchRules{
+	matchRegexRules := model.PortMatchRules{
 		MatchIndexRegexes: []model.PortMatchRule{
 			{
 				Regex:     regexp.MustCompile(`.Run\(([^,)]*)`),
@@ -49,15 +48,8 @@ func (g GinDetector) DoPortsDetection(component *model.Component, ctx *context.C
 		},
 	}
 
-	for _, file := range files {
-		bytes, err := os.ReadFile(file)
-		if err != nil {
-			continue
-		}
-		ports := GetPortFromFileGo(matchRegexRule, string(bytes))
-		if len(ports) > 0 {
-			component.Ports = ports
-			return
-		}
+	ports := GetPortFromFilesGo(matchRegexRules, files)
+	if len(ports) > 0 {
+		component.Ports = ports
 	}
 }

--- a/go/pkg/apis/enricher/framework/go/go_detector.go
+++ b/go/pkg/apis/enricher/framework/go/go_detector.go
@@ -14,6 +14,7 @@ package enricher
 import (
 	"context"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -57,16 +58,9 @@ func DoGoPortsDetection(component *model.Component, ctx *context.Context) {
 		},
 	}
 
-	for _, file := range files {
-		bytes, err := os.ReadFile(file)
-		if err != nil {
-			continue
-		}
-		ports := GetPortFromFileGo(matchRegexRules, string(bytes))
-		if len(ports) > 0 {
-			component.Ports = ports
-			return
-		}
+	ports := GetPortFromFilesGo(matchRegexRules, files)
+	if len(ports) > 0 {
+		component.Ports = ports
 	}
 }
 
@@ -133,4 +127,21 @@ func GetPortWithMatchIndexesGo(content string, matchIndexes []int, toBeReplaced 
 	}
 
 	return -1
+}
+
+// GetPortFromFilesGo loops through a list of paths and tries to find a port matching the
+// given set PortMatchRules
+func GetPortFromFilesGo(matchRegexRules model.PortMatchRules, files []string) []int {
+	for _, file := range files {
+		cleanFile := filepath.Clean(file)
+		bytes, err := os.ReadFile(cleanFile)
+		if err != nil {
+			continue
+		}
+		ports := GetPortFromFileGo(matchRegexRules, string(bytes))
+		if len(ports) > 0 {
+			return ports
+		}
+	}
+	return []int{}
 }

--- a/go/pkg/apis/enricher/framework/go/gofiber_detector.go
+++ b/go/pkg/apis/enricher/framework/go/gofiber_detector.go
@@ -13,7 +13,6 @@ package enricher
 
 import (
 	"context"
-	"os"
 	"regexp"
 
 	"github.com/redhat-developer/alizer/go/pkg/apis/model"
@@ -40,7 +39,7 @@ func (g GoFiberDetector) DoPortsDetection(component *model.Component, ctx *conte
 		return
 	}
 
-	matchRegexRule := model.PortMatchRules{
+	matchRegexRules := model.PortMatchRules{
 		MatchIndexRegexes: []model.PortMatchRule{
 			{
 				Regex:     regexp.MustCompile(`.Listen\(([^,)]*)`),
@@ -48,15 +47,8 @@ func (g GoFiberDetector) DoPortsDetection(component *model.Component, ctx *conte
 			},
 		},
 	}
-	for _, file := range files {
-		bytes, err := os.ReadFile(file)
-		if err != nil {
-			continue
-		}
-		ports := GetPortFromFileGo(matchRegexRule, string(bytes))
-		if len(ports) > 0 {
-			component.Ports = ports
-			return
-		}
+	ports := GetPortFromFilesGo(matchRegexRules, files)
+	if len(ports) > 0 {
+		component.Ports = ports
 	}
 }

--- a/go/pkg/apis/enricher/framework/go/mux_detector.go
+++ b/go/pkg/apis/enricher/framework/go/mux_detector.go
@@ -13,7 +13,6 @@ package enricher
 
 import (
 	"context"
-	"os"
 	"regexp"
 
 	"github.com/redhat-developer/alizer/go/pkg/apis/model"
@@ -55,15 +54,8 @@ func (m MuxDetector) DoPortsDetection(component *model.Component, ctx *context.C
 		},
 	}
 
-	for _, file := range files {
-		bytes, err := os.ReadFile(file)
-		if err != nil {
-			continue
-		}
-		ports := GetPortFromFileGo(matchRegexRules, string(bytes))
-		if len(ports) > 0 {
-			component.Ports = ports
-			return
-		}
+	ports := GetPortFromFilesGo(matchRegexRules, files)
+	if len(ports) > 0 {
+		component.Ports = ports
 	}
 }

--- a/go/pkg/apis/enricher/framework/java/micronaut_detector.go
+++ b/go/pkg/apis/enricher/framework/java/micronaut_detector.go
@@ -76,7 +76,10 @@ func (m MicronautDetector) DoPortsDetection(component *model.Component, ctx *con
 func getMicronautPortsFromBytes(bytes []byte) []int {
 	var ports []int
 	var data MicronautApplicationProps
-	yaml.Unmarshal(bytes, &data)
+	err := yaml.Unmarshal(bytes, &data)
+	if err != nil {
+		return []int{}
+	}
 	if data.Micronaut.Server.SSL.Enabled && utils.IsValidPort(data.Micronaut.Server.SSL.Port) {
 		ports = append(ports, data.Micronaut.Server.SSL.Port)
 	}

--- a/go/pkg/apis/enricher/framework/java/openliberty_detector.go
+++ b/go/pkg/apis/enricher/framework/java/openliberty_detector.go
@@ -55,7 +55,10 @@ func (o OpenLibertyDetector) DoPortsDetection(component *model.Component, ctx *c
 		return
 	}
 	var data ServerXml
-	xml.Unmarshal(bytes, &data)
+	err = xml.Unmarshal(bytes, &data)
+	if err != nil {
+		return
+	}
 	ports := utils.GetValidPorts([]string{data.HttpEndpoint.HttpPort, data.HttpEndpoint.HttpsPort})
 	if len(ports) > 0 {
 		component.Ports = ports

--- a/go/pkg/apis/enricher/framework/java/quarkus_detector.go
+++ b/go/pkg/apis/enricher/framework/java/quarkus_detector.go
@@ -140,7 +140,10 @@ func getServerPortsFromQuarkusApplicationYamlFile(file string) ([]int, error) {
 		return []int{}, err
 	}
 	var data QuarkusApplicationYaml
-	yaml.Unmarshal(yamlFile, &data)
+	err = yaml.Unmarshal(yamlFile, &data)
+	if err != nil {
+		return []int{}, err
+	}
 	var ports []int
 	if data.Quarkus.Http.SSLPort > 0 {
 		ports = append(ports, data.Quarkus.Http.SSLPort)

--- a/go/pkg/apis/enricher/framework/java/spring_detector.go
+++ b/go/pkg/apis/enricher/framework/java/spring_detector.go
@@ -127,7 +127,10 @@ func getServerPortsFromYamlFile(file string) ([]int, error) {
 		return []int{}, err
 	}
 	var data ApplicationProsServer
-	yaml.Unmarshal(yamlFile, &data)
+	err = yaml.Unmarshal(yamlFile, &data)
+	if err != nil {
+		return []int{}, err
+	}
 	var ports []int
 	if data.Server.Port > 0 {
 		ports = append(ports, data.Server.Port)

--- a/go/pkg/apis/enricher/framework/javascript/nodejs/express_detector.go
+++ b/go/pkg/apis/enricher/framework/javascript/nodejs/express_detector.go
@@ -14,6 +14,7 @@ package enricher
 import (
 	"context"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -43,7 +44,8 @@ func (e ExpressDetector) DoPortsDetection(component *model.Component, ctx *conte
 	re := regexp.MustCompile(`\.listen\([^,)]*`)
 	var ports []int
 	for _, file := range files {
-		bytes, err := os.ReadFile(file)
+		cleanFile := filepath.Clean(file)
+		bytes, err := os.ReadFile(cleanFile)
 		if err != nil {
 			continue
 		}

--- a/go/pkg/apis/enricher/java_enricher.go
+++ b/go/pkg/apis/enricher/java_enricher.go
@@ -107,7 +107,8 @@ func getProjectNameGradle(root string) string {
 	settingsGradlePath := filepath.Join(root, "settings.gradle")
 	if _, err := os.Stat(settingsGradlePath); err == nil {
 		re := regexp.MustCompile(`rootProject.name\s*=\s*(.*)`)
-		bytes, err := os.ReadFile(settingsGradlePath)
+		cleanSettingsGradlePath := filepath.Clean(settingsGradlePath)
+		bytes, err := os.ReadFile(cleanSettingsGradlePath)
 		if err != nil {
 			return ""
 		}

--- a/go/pkg/apis/recognizer/devfile_recognizer.go
+++ b/go/pkg/apis/recognizer/devfile_recognizer.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"regexp"
@@ -138,7 +139,12 @@ func downloadDevFileTypesFromRegistry(url string) ([]model.DevFileType, error) {
 			return []model.DevFileType{}, err
 		}
 	}
-	defer resp.Body.Close()
+	defer func() error {
+		if err := resp.Body.Close(); err != nil {
+			return fmt.Errorf("error closing file: %s", err)
+		}
+		return nil
+	}()
 
 	// Check server response
 	if resp.StatusCode != http.StatusOK {

--- a/go/pkg/utils/detector.go
+++ b/go/pkg/utils/detector.go
@@ -146,8 +146,10 @@ func GetPomFileContent(pomFilePath string) (schema.Pom, error) {
 	byteValue, _ := ioutil.ReadAll(xmlFile)
 
 	var pom schema.Pom
-	xml.Unmarshal(byteValue, &pom)
-
+	err = xml.Unmarshal(byteValue, &pom)
+	if err != nil {
+		return schema.Pom{}, err
+	}
 	defer func() error {
 		if err := xmlFile.Close(); err != nil {
 			return fmt.Errorf("error closing file: %s", err)
@@ -191,7 +193,10 @@ func GetPackageJsonSchemaFromFile(path string) (schema.PackageJson, error) {
 	}
 
 	var packageJson schema.PackageJson
-	json.Unmarshal(bytes, &packageJson)
+	err = json.Unmarshal(bytes, &packageJson)
+	if err != nil {
+		return schema.PackageJson{}, err
+	}
 	return packageJson, nil
 }
 
@@ -217,7 +222,10 @@ func GetComposerJsonSchemaFromFile(path string) (schema.ComposerJson, error) {
 	}
 
 	var composerJson schema.ComposerJson
-	json.Unmarshal(bytes, &composerJson)
+	err = json.Unmarshal(bytes, &composerJson)
+	if err != nil {
+		return schema.ComposerJson{}, err
+	}
 	return composerJson, nil
 }
 

--- a/go/pkg/utils/detector.go
+++ b/go/pkg/utils/detector.go
@@ -187,7 +187,8 @@ func isTagInDependencies(deps map[string]string, tag string) bool {
 
 // GetPackageJsonSchemaFromFile returns the package.json found in the path.
 func GetPackageJsonSchemaFromFile(path string) (schema.PackageJson, error) {
-	bytes, err := os.ReadFile(path)
+	cleanPath := filepath.Clean(path)
+	bytes, err := os.ReadFile(cleanPath)
 	if err != nil {
 		return schema.PackageJson{}, err
 	}
@@ -216,7 +217,8 @@ func IsTagInComposerJsonFile(file string, tag string) bool {
 
 // GetComposerJsonSchemaFromFile returns the composer.json found in the path.
 func GetComposerJsonSchemaFromFile(path string) (schema.ComposerJson, error) {
-	bytes, err := os.ReadFile(path)
+	cleanPath := filepath.Clean(path)
+	bytes, err := os.ReadFile(cleanPath)
 	if err != nil {
 		return schema.ComposerJson{}, err
 	}
@@ -513,7 +515,8 @@ func GetStringValueFromEnvFile(root string, regex string) string {
 // getEnvFileContent is exposed as a global variable for the purpose of running mock tests
 var getEnvFileContent = func(root string) (string, error) {
 	envPath := filepath.Join(root, ".env")
-	bytes, err := os.ReadFile(envPath)
+	cleanEnvPath := filepath.Clean(envPath)
+	bytes, err := os.ReadFile(cleanEnvPath)
 	if err != nil {
 		return "", err
 	}

--- a/go/pkg/utils/detector.go
+++ b/go/pkg/utils/detector.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -147,7 +148,12 @@ func GetPomFileContent(pomFilePath string) (schema.Pom, error) {
 	var pom schema.Pom
 	xml.Unmarshal(byteValue, &pom)
 
-	defer xmlFile.Close()
+	defer func() error {
+		if err := xmlFile.Close(); err != nil {
+			return fmt.Errorf("error closing file: %s", err)
+		}
+		return nil
+	}()
 	return pom, nil
 }
 

--- a/go/pkg/utils/detector.go
+++ b/go/pkg/utils/detector.go
@@ -18,13 +18,14 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"errors"
-	"github.com/redhat-developer/alizer/go/pkg/utils/langfiles"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/redhat-developer/alizer/go/pkg/utils/langfiles"
 
 	"github.com/redhat-developer/alizer/go/pkg/apis/model"
 	"github.com/redhat-developer/alizer/go/pkg/schema"
@@ -136,7 +137,8 @@ func IsTagInPomXMLFile(pomFilePath string, tag string) (bool, error) {
 
 // GetPomFileContent returns the pom found in the path.
 func GetPomFileContent(pomFilePath string) (schema.Pom, error) {
-	xmlFile, err := os.Open(pomFilePath)
+	cleanPomFilePath := filepath.Clean(pomFilePath)
+	xmlFile, err := os.Open(cleanPomFilePath)
 	if err != nil {
 		return schema.Pom{}, err
 	}

--- a/go/pkg/utils/langfiles/languages_file_handler.go
+++ b/go/pkg/utils/langfiles/languages_file_handler.go
@@ -114,7 +114,10 @@ func getLanguagesProperties() schema.LanguagesProperties {
 		return schema.LanguagesProperties{}
 	}
 	var data schema.LanguagesProperties
-	yaml.Unmarshal(yamlFile, &data)
+	err = yaml.Unmarshal(yamlFile, &data)
+	if err != nil {
+		return schema.LanguagesProperties{}
+	}
 	return data
 }
 
@@ -125,7 +128,10 @@ func getLanguageCustomizations() schema.LanguagesCustomizations {
 	}
 
 	var data schema.LanguagesCustomizations
-	yaml.Unmarshal(yamlFile, &data)
+	err = yaml.Unmarshal(yamlFile, &data)
+	if err != nil {
+		return schema.LanguagesCustomizations{}
+	}
 	return data
 }
 

--- a/go/test/apis/component_recognizer_test.go
+++ b/go/test/apis/component_recognizer_test.go
@@ -12,6 +12,7 @@ package recognizer
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -163,7 +164,12 @@ func updateContent(filePath string, data []byte) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer func() error {
+		if err := f.Close(); err != nil {
+			return fmt.Errorf("error closing file: %s", err)
+		}
+		return nil
+	}()
 	if _, err := f.Write(data); err != nil {
 		return err
 	}


### PR DESCRIPTION
## What does this PR do?

Fixes several warnings from gosec security check:

* Potential file inclusion: It fixes the issue by using the `filepath.Clean()` func before using the `os.Open()` func.
* Defering unsafe method: Adds error handling cases inside defer funcs used for `file.Close()` funcs.
* Errors unhandled: For each `Unmarshal()` func used without error handling, it adds the appropriate error handling.

### Which issue(s) does this PR fix

<!-- _Link to github issue(s)_ -->
Fixes #222 

### PR acceptance criteria

Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

- [x] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [x] Documentation

   <!-- _This includes product docs and READMEs._ -->

### How to test changes / Special notes to the reviewer
