### PR TITLE
Add min max cli args

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ $ go build alizer.go
 
 ```sh
   --port-detection {docker|compose|source}    port detection strategy to use when detecting a port. Currently supported strategies are 'docker', 'compose' and 'source'. You can pass more strategies at the same time. They will be executed in order. By default Alizer will execute docker, compose and source.
+  --log {debug|info|warning}    sets the logging level of the CLI. The arg accepts only 3 values [`debug`, `info`, `warning`]. The default value is `warning` and the logging level is `ErrorLevel`.
 ```
 
 #### alizer devfile
@@ -55,6 +56,9 @@ $ go build alizer.go
 
 ```sh
   --registry strings    registry where to download the devfiles. Default value: https://registry.devfile.io
+  --log {debug|info|warning}    sets the logging level of the CLI. The arg accepts only 3 values [`debug`, `info`, `warning`]. The default value is `warning` and the logging level is `ErrorLevel`.
+  --min-version strings the minimum SchemaVersion of the matched devfile(s). The minimum accepted value is `2.0.0`, otherwise an error is returned.
+  --max-version strings the maximum SchemaVersion of the matched devfile(s). The minimum accepted value is `2.0.0`, otherwise an error is returned.
 ```
 
 ### Library Package

--- a/docs/proposals/support_22x_devfiles.md
+++ b/docs/proposals/support_22x_devfiles.md
@@ -185,7 +185,7 @@ filter := map[string]interface{} {
         "max-version": "2.1.0",
         "min-version": "2.0.0",
 }
-devfiles, err := recognizer.SelectDevFilesFromTypesWithArgs("myproject", devfiles, filter)
+devfiles, err := recognizer.MatchDevfiles("myproject", devfiles, filter)
 ```
 
 ### model.DevfileType

--- a/go/go.mod
+++ b/go/go.mod
@@ -5,6 +5,7 @@ go 1.19
 require (
 	github.com/go-git/go-git/v5 v5.5.1
 	github.com/go-logr/logr v1.2.4
+	github.com/hashicorp/go-version v1.6.0
 	github.com/moby/buildkit v0.10.6
 	github.com/pkg/errors v0.9.1
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06

--- a/go/go.mod
+++ b/go/go.mod
@@ -32,7 +32,6 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/gofuzz v1.1.0 // indirect
-	github.com/hashicorp/go-version v1.6.0 // indirect
 	github.com/imdario/mergo v0.3.15 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect

--- a/go/go.mod
+++ b/go/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/gofuzz v1.1.0 // indirect
+	github.com/hashicorp/go-version v1.6.0 // indirect
 	github.com/imdario/mergo v0.3.15 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect

--- a/go/go.sum
+++ b/go/go.sum
@@ -55,6 +55,8 @@ github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/
 github.com/google/gofuzz v1.1.0 h1:Hsa8mG0dQ46ij8Sl2AYJDUv1oA9/d6Vk+3LG99Oe02g=
 github.com/google/gofuzz v1.1.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 h1:K6RDEckDVWvDI9JAJYCmNdQXq6neHJOYx3V6jnqNEec=
+github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mOkIeek=
+github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/imdario/mergo v0.3.13/go.mod h1:4lJ1jqUDcsbIECGy0RUJAXNIhg+6ocWgb1ALK2O4oXg=
 github.com/imdario/mergo v0.3.15 h1:M8XP7IuFNsqUx6VPK2P9OSmsYsI/YFaGil0uD21V3dM=
 github.com/imdario/mergo v0.3.15/go.mod h1:WBLT9ZmE3lPoWsEzCh9LPo3TiwVN+ZKEjmz+hD27ysY=

--- a/go/pkg/apis/model/model.go
+++ b/go/pkg/apis/model/model.go
@@ -42,11 +42,18 @@ type Component struct {
 	Ports     []int
 }
 
+type Version struct {
+	SchemaVersion string
+	Default       bool
+	Version       string
+}
+
 type DevFileType struct {
 	Name        string
 	Language    string
 	ProjectType string
 	Tags        []string
+	Versions    []Version
 }
 
 type ApplicationFileInfo struct {

--- a/go/pkg/apis/model/model.go
+++ b/go/pkg/apis/model/model.go
@@ -56,6 +56,11 @@ type DevFileType struct {
 	Versions    []Version
 }
 
+type DevfileFilter struct {
+	MinVersion string
+	MaxVersion string
+}
+
 type ApplicationFileInfo struct {
 	Dir  string
 	File string

--- a/go/pkg/apis/recognizer/devfile_recognizer.go
+++ b/go/pkg/apis/recognizer/devfile_recognizer.go
@@ -210,7 +210,8 @@ func downloadDevFileTypesFromRegistry(url string, filter model.DevfileFilter) ([
 	if err != nil {
 		return nil, err
 	}
-	resp, err := http.Get(url)
+	// This value is set by the user in order to configure the registry
+	resp, err := http.Get(url) //nolint
 	if err != nil {
 		return []model.DevFileType{}, err
 	}

--- a/go/pkg/apis/recognizer/devfile_recognizer.go
+++ b/go/pkg/apis/recognizer/devfile_recognizer.go
@@ -104,6 +104,9 @@ func SelectDevFileUsingLanguagesFromTypes(languages []model.Language, devFileTyp
 }
 
 func MatchDevfiles(path, url, minVersion, maxVersion string) ([]model.DevFileType, error) {
+	alizerLogger := utils.GetOrCreateLogger()
+	alizerLogger.V(0).Info("Starting devfile matching")
+	alizerLogger.V(1).Info(fmt.Sprintf("Downloading devfiles from registry %s", url))
 	devFileTypesFromRegistry, err := downloadDevFileTypesFromRegistry(url, minVersion, maxVersion)
 	if err != nil {
 		return []model.DevFileType{}, err

--- a/go/pkg/cli/devfile/devfile.go
+++ b/go/pkg/cli/devfile/devfile.go
@@ -6,7 +6,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var logLevel, registry string
+var logLevel, registry, minVersion, maxVersion string
 
 func NewCmdDevfile() *cobra.Command {
 	devfileCmd := &cobra.Command{
@@ -17,6 +17,8 @@ func NewCmdDevfile() *cobra.Command {
 		Run:   doSelectDevfile,
 	}
 	devfileCmd.Flags().StringVar(&logLevel, "log", "", "log level for alizer. Default value: error. Accepted values: [debug, info, warning]")
+	devfileCmd.Flags().StringVar(&minVersion, "min-version", "", "minimum version of devfile schemaVersion")
+	devfileCmd.Flags().StringVar(&maxVersion, "max-version", "", "maximum version of devfile schemaVersion")
 	devfileCmd.Flags().StringVarP(&registry, "registry", "r", "", "registry where to download the devfiles. Default value: https://registry.devfile.io")
 	return devfileCmd
 }
@@ -27,12 +29,12 @@ func doSelectDevfile(cmd *cobra.Command, args []string) {
 		return
 	}
 	if registry == "" {
-		registry = "https://registry.devfile.io/index"
+		registry = "https://registry.devfile.io/"
 	}
 	err := utils.GenLogger(logLevel)
 	if err != nil {
 		utils.PrintWrongLoggingLevelMessage(cmd.Name())
 		return
 	}
-	utils.PrintPrettifyOutput(recognizer.SelectDevFilesFromRegistry(args[0], registry))
+	utils.PrintPrettifyOutput(recognizer.MatchDevfiles(args[0], registry, minVersion, maxVersion))
 }

--- a/go/pkg/cli/devfile/devfile.go
+++ b/go/pkg/cli/devfile/devfile.go
@@ -1,6 +1,7 @@
 package devfile
 
 import (
+	"github.com/redhat-developer/alizer/go/pkg/apis/model"
 	"github.com/redhat-developer/alizer/go/pkg/apis/recognizer"
 	"github.com/redhat-developer/alizer/go/pkg/utils"
 	"github.com/spf13/cobra"
@@ -17,8 +18,8 @@ func NewCmdDevfile() *cobra.Command {
 		Run:   doSelectDevfile,
 	}
 	devfileCmd.Flags().StringVar(&logLevel, "log", "", "log level for alizer. Default value: error. Accepted values: [debug, info, warning]")
-	devfileCmd.Flags().StringVar(&minVersion, "min-version", "", "minimum version of devfile schemaVersion")
-	devfileCmd.Flags().StringVar(&maxVersion, "max-version", "", "maximum version of devfile schemaVersion")
+	devfileCmd.Flags().StringVar(&minVersion, "min-version", "", "minimum version of devfile schemaVersion. Minimum allowed version: 2.0.0")
+	devfileCmd.Flags().StringVar(&maxVersion, "max-version", "", "maximum version of devfile schemaVersion. Minimum allowed version: 2.0.0")
 	devfileCmd.Flags().StringVarP(&registry, "registry", "r", "", "registry where to download the devfiles. Default value: https://registry.devfile.io")
 	return devfileCmd
 }
@@ -36,5 +37,9 @@ func doSelectDevfile(cmd *cobra.Command, args []string) {
 		utils.PrintWrongLoggingLevelMessage(cmd.Name())
 		return
 	}
-	utils.PrintPrettifyOutput(recognizer.MatchDevfiles(args[0], registry, minVersion, maxVersion))
+	filter := model.DevfileFilter{
+		MinVersion: minVersion,
+		MaxVersion: maxVersion,
+	}
+	utils.PrintPrettifyOutput(recognizer.MatchDevfiles(args[0], registry, filter))
 }

--- a/go/test/apis/devfile_recognizer_test.go
+++ b/go/test/apis/devfile_recognizer_test.go
@@ -11,10 +11,12 @@ package recognizer
  * Red Hat, Inc.
  ******************************************************************************/
 import (
+	"fmt"
 	"testing"
 
 	"github.com/redhat-developer/alizer/go/pkg/apis/model"
 	"github.com/redhat-developer/alizer/go/pkg/apis/recognizer"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestDetectQuarkusDevfile(t *testing.T) {
@@ -131,6 +133,100 @@ func TestDetectSpringDevfile(t *testing.T) {
 
 func TestDetectLaravelDevfile(t *testing.T) {
 	detectDevFiles(t, "laravel", []string{"php-laravel"})
+}
+
+func TestGetUrlWithVersions(t *testing.T) {
+	tests := []struct {
+		name          string
+		minVersion    string
+		maxVersion    string
+		testUrl       string
+		expectedError error
+		expectedUrl   string
+	}{
+		{
+
+			name:          "Case 1: Url with valid min and max versions",
+			minVersion:    "2.0.0",
+			maxVersion:    "2.2.0",
+			testUrl:       "http://localhost:5000/",
+			expectedError: nil,
+		},
+		{
+			name:          "Case 2: Url with valid min version",
+			minVersion:    "2.0.0",
+			maxVersion:    "",
+			testUrl:       "http://localhost:5000",
+			expectedError: nil,
+		},
+		{
+			name:          "Case 3: Url with valid max version",
+			minVersion:    "",
+			maxVersion:    "2.2.0",
+			testUrl:       "http://localhost:5000/",
+			expectedError: nil,
+		},
+		{
+			name:          "Case 4: Url with max version lower than min version",
+			minVersion:    "2.2.0",
+			maxVersion:    "2.1.0",
+			testUrl:       "http://localhost:5000/v2index",
+			expectedError: fmt.Errorf("max-version cannot be lower than min-version"),
+		},
+		{
+			name:          "Case 5: Url with max version lower than minimum allowed version",
+			minVersion:    "0.1.0",
+			maxVersion:    "1.1.0",
+			testUrl:       "http://localhost:5000/v2index",
+			expectedError: fmt.Errorf("min and/or max version are lower than the minimum allowed version (2.0.0)"),
+		},
+		{
+			name:          "Case 6: Url with max version lower than minimum allowed version & minVersion",
+			minVersion:    "2.1.0",
+			maxVersion:    "1.1.0",
+			testUrl:       "http://localhost:5000/v2index",
+			expectedError: fmt.Errorf("max-version cannot be lower than min-version"),
+		},
+		{
+			name:          "Case 7: Url with min version lower than minimum allowed version",
+			minVersion:    "1.1.0",
+			maxVersion:    "",
+			testUrl:       "http://localhost:5000/v2index",
+			expectedError: fmt.Errorf("min version is lower than the minimum allowed version (2.0.0)"),
+		},
+		{
+			name:          "Case 8: Url with max version lower than minimum allowed version",
+			minVersion:    "",
+			maxVersion:    "1.1.0",
+			testUrl:       "http://localhost:5000/v2index",
+			expectedError: fmt.Errorf("max version is lower than the minimum allowed version (2.0.0)"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := recognizer.GetUrlWithVersions(tt.testUrl, tt.minVersion, tt.maxVersion)
+			if err != nil {
+				assert.EqualValues(t, tt.expectedError, err)
+			} else {
+				assert.EqualValues(t, getExceptedVersionsUrl(tt.testUrl, tt.minVersion, tt.maxVersion, tt.expectedError), result)
+			}
+		})
+	}
+}
+
+func getExceptedVersionsUrl(url, minVersion, maxVersion string, err error) string {
+	if err != nil {
+		return ""
+	} else if minVersion != "" && maxVersion != "" {
+		return fmt.Sprintf("%s?minSchemaVersion=%s&maxSchemaVersion=%s", url, minVersion, maxVersion)
+	} else if minVersion != "" {
+		return fmt.Sprintf("%s?minSchemaVersion=%s", url, minVersion)
+	} else if maxVersion != "" {
+		return fmt.Sprintf("%s?maxSchemaVersion=%s", url, maxVersion)
+	} else {
+		return url
+	}
 }
 
 func detectDevFiles(t *testing.T, projectName string, devFilesName []string) {


### PR DESCRIPTION
## What does this PR do?

As part of #159 we are introducing the two first cli args in order to support specific versions of devfiles. Those two are `min-version` and `max-version`.

If this argument is passed in the cli we are updating the URL for the download of the devfiles from the registry (following this [link](https://github.com/devfile/registry-support/blob/main/index/server/registry-REST-API.adoc#query-parameters)). This way we are filtering the list of devfiles we are getting from the registry.

Some edge cases:
* If `min-version` is higher than `max-version` an `error` is raised.
* If `min-version` and/or `max-version` is lower than `2.0.0` (the lowest accepted version from the registry API) then an error is raised.

A slight addition is also made to the `model.DevfileType` in order to include information for versions. For backwards compatibility reasons we are no longer using `SelectDevFilesFromRegistry` but `MatchDevfiles`.

A new `model.DevfileFilter` is created in order to include all future filters inside the devfile API and ensure scalability.

Updates are made inside the documentation of the project to include all changes introduced and test cases regarding the URL update are added.

### Which issue(s) does this PR fix

fixes #226 
<!-- _Link to github issue(s)_ -->

### PR acceptance criteria

Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [x] Documentation

   <!-- _This includes product docs and READMEs._ -->

### How to test changes / Special notes to the reviewer
