### PR TITLE
Add binaries to every new release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,7 +49,6 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           draft: false
-          generate_release_notes: true
           files: go/${{env.BINARY_NAME}}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,55 @@
+on:
+  push:
+    tags:
+      - 'v*'
+
+name: Build Release
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Create Release
+    runs-on: 'ubuntu-latest'
+    strategy:
+      matrix:
+        goosarch:
+          - 'darwin/amd64'
+          - 'linux/amd64'
+          - 'linux/ppc64le'
+          - 'linux/s390x'
+          - 'windows/amd64'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.19.5'
+      - name: Get OS and arch info
+        run: |
+          GOOSARCH=${{matrix.goosarch}}
+          GOOS=${GOOSARCH%/*}
+          GOARCH=${GOOSARCH#*/}
+          BINARY_NAME=alizer-$GOOS-$GOARCH
+          echo "BINARY_NAME=$BINARY_NAME" >> $GITHUB_ENV
+          echo "GOOS=$GOOS" >> $GITHUB_ENV
+          echo "GOARCH=$GOARCH" >> $GITHUB_ENV
+      - name: Build
+        run: |
+          cd go/
+          go build -o "$BINARY_NAME" -v
+      - name: Release with Notes and Binaries
+        uses: softprops/action-gh-release@v1
+        with:
+          draft: false
+          generate_release_notes: true
+          files: go/${{env.BINARY_NAME}}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ For information on getting started, refer to the [CONTRIBUTING instructions](CON
 
 The release process of `alizer` is very straightforward. You can create a new release [here](https://github.com/redhat-developer/alizer/releases/new).
 
-- The _title_ of the release has to be the new version. `Alizer` follows the `{major}.{minor}.{bugfix}` format (e.g `0.1.0`)
+- The _title_ of the release has to be the new version. `Alizer` follows the `v{major}.{minor}.{bugfix}` format (e.g `v0.1.0`)
 - The _description_ of the release is optional. You may add a description if there were outstanding updates in the project, not mentioned in the issues or PRs of this release.
 
 ## Feedback & Questions

--- a/README.md
+++ b/README.md
@@ -163,6 +163,18 @@ The release process of `alizer` is very straightforward. You can create a new re
 - The _title_ of the release has to be the new version. `Alizer` follows the `v{major}.{minor}.{bugfix}` format (e.g `v0.1.0`)
 - The _description_ of the release is optional. You may add a description if there were outstanding updates in the project, not mentioned in the issues or PRs of this release.
 
+### Release Binaries
+For each release a group of binary files is generated. More detailed we have the following types:
+- `linux/amd64`
+- `linux/ppc65le`
+- `linux/s390x`
+- `windows/amd64`
+- `darwin/amd64`
+
+In order to download a binary file:
+* Go to the release you are interested for `https://github.com/thepetk/alizer/releases/tag/<release-tag>`
+* In the **Assets** section you will see the list of generated binaries for the release.
+
 ## Feedback & Questions
 
 If you discover an issue please file a bug and we will fix it as soon as possible.


### PR DESCRIPTION
## What does this PR do?

Introduces the `release.yaml` workflow which will add 5 binaries into an existing release. Those will be:
```yaml
goosarch:
  - 'darwin/amd64'
  - 'linux/amd64'
  - 'linux/ppc64le'
  - 'linux/s390x'
  - 'windows/amd64'
```
The flow of a release would require a user to push a tag in order to trigger this workflow. As a result those 5 binaries will be added to the tag.

Our release process remains the same:
- Create a new release with a new tag.
- The tag has to start with "v" in order to trigger the binary creation job.
- [Optional] Autogenerate the release notes
- Creating the release with a new "v" tag triggers the `release.yaml`
- The binaries are added to the new tag and they are reachable through the new release.

### Which issue(s) does this PR fix
fixes #40 

### PR acceptance criteria

Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

- [x] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [x] Documentation

   <!-- _This includes product docs and READMEs._ -->

### How to test changes / Special notes to the reviewer
A test run for this flow has already tested here: https://github.com/thepetk/alizer/releases/tag/v1.0.0