### PR TITLE
feat: improve Quarkus component detection

### DIFF
--- a/go/pkg/apis/enricher/framework/java/quarkus_detector.go
+++ b/go/pkg/apis/enricher/framework/java/quarkus_detector.go
@@ -45,7 +45,10 @@ func (q QuarkusDetector) GetSupportedFrameworks() []string {
 
 // DoFrameworkDetection uses the groupId to check for the framework name
 func (q QuarkusDetector) DoFrameworkDetection(language *model.Language, config string) {
-	if hasFwk, _ := hasFramework(config, "io.quarkus", ""); hasFwk {
+	//note that we don't specify the group id because this can sometimes be a property substitution
+	if hasFwk, _ := hasFramework(config, "", "quarkus-maven-plugin"); hasFwk {
+		language.Frameworks = append(language.Frameworks, "Quarkus")
+	} else if hasFwk, _ = hasFramework(config, "", "io.quarkus.gradle.plugin"); hasFwk {
 		language.Frameworks = append(language.Frameworks, "Quarkus")
 	}
 }

--- a/go/pkg/apis/enricher/java_enricher.go
+++ b/go/pkg/apis/enricher/java_enricher.go
@@ -51,11 +51,14 @@ func (j JavaEnricher) DoEnrichLanguage(language *model.Language, files *[]string
 	if gradle != "" {
 		language.Tools = []string{"Gradle"}
 		detectJavaFrameworks(language, gradle)
+		language.FrameworkPreferred = true
 	} else if maven != "" {
 		language.Tools = []string{"Maven"}
 		detectJavaFrameworks(language, maven)
+		language.FrameworkPreferred = true
 	} else if ant != "" {
 		language.Tools = []string{"Ant"}
+		language.FrameworkPreferred = true
 	}
 }
 

--- a/go/pkg/apis/model/model.go
+++ b/go/pkg/apis/model/model.go
@@ -33,6 +33,9 @@ type Language struct {
 	Frameworks     []string
 	Tools          []string
 	CanBeComponent bool
+	//if this is true then if a framework is discovered for one module non-framework modules will be removed
+	//this is useful for Java which often has a lot of support modules that are not components
+	FrameworkPreferred bool
 }
 
 type Component struct {

--- a/go/test/apis/git_recognizer_test.go
+++ b/go/test/apis/git_recognizer_test.go
@@ -45,6 +45,7 @@ func TestExternalRepos(t *testing.T) {
 		result := checkoutAndTest(root, properties)
 		if len(result.errors) > 0 {
 			for _, err := range result.errors {
+				println("Failed on project " + properties.Directory)
 				t.Error(err)
 			}
 			t.Fatal("TestExternalRepos failed")


### PR DESCRIPTION
Quarkus projects often have lots of modules that are not intended to be components, but still have io.quarkus dependencies.

This commit will only mark a module as a Quarkus component if it explicitly references the Quarkus plugin that creates a runnable application.

In addition if a Java project contains components that explicitly specify frameworks then modules without frameworks will be removed.

This will help with the usability issues identified in RHTAPBUGS-552. 

Testing against Apicurio Registry this reduces the component count down from 50 to 8, which is expected.
